### PR TITLE
new port: devel/py-decorator4

### DIFF
--- a/devel/Makefile
+++ b/devel/Makefile
@@ -4357,6 +4357,7 @@
     SUBDIR += py-debtcollector
     SUBDIR += py-debugtools
     SUBDIR += py-decorator
+    SUBDIR += py-decorator4
     SUBDIR += py-decoratortools
     SUBDIR += py-deepdiff
     SUBDIR += py-deepmerge

--- a/devel/py-decorator4/Makefile
+++ b/devel/py-decorator4/Makefile
@@ -1,0 +1,25 @@
+PORTNAME=	decorator
+PORTVERSION=	4.4.2
+CATEGORIES=	devel python
+MASTER_SITES=	CHEESESHOP
+PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
+PKGNAMESUFFIX=	4
+
+MAINTAINER=	ygy@FreeBSD.org
+COMMENT=	Decorators for Humans
+
+LICENSE=	MIT
+LICENSE_FILE=	${WRKSRC}/LICENSE.txt
+
+DEPRECATED=	Legacy version, use devel/py-decorator instead
+EXPIRATION_DATE=2021-12-31
+
+USES=		python:3.6+
+USE_PYTHON=	distutils autoplist
+
+NO_ARCH=	yes
+
+do-test:
+	@cd ${WRKSRC} && ${PYTHON_CMD} ${PYDISTUTILS_SETUP} test
+
+.include <bsd.port.mk>

--- a/devel/py-decorator4/distinfo
+++ b/devel/py-decorator4/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1584984981
+SHA256 (decorator-4.4.2.tar.gz) = e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7
+SIZE (decorator-4.4.2.tar.gz) = 33629

--- a/devel/py-decorator4/pkg-descr
+++ b/devel/py-decorator4/pkg-descr
@@ -1,0 +1,14 @@
+As of now, writing custom decorators correctly requires some
+experience and it is not as easy as it could be. For instance, typical
+implementations of decorators involve nested functions, and we all
+know that flat is better than nested. Moreover, typical
+implementations of decorators do not preserve the signature of
+decorated functions, thus confusing both documentation tools and
+developers.
+
+The aim of the decorator module it to simplify the usage of decorators
+for the average programmer, and to popularize decorators usage giving
+examples of useful decorators, such as memoize, tracing,
+redirecting_stdout, locked, etc.
+
+WWW: https://github.com/micheles/decorator

--- a/devel/py-pytest-relaxed/Makefile
+++ b/devel/py-pytest-relaxed/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	pytest-relaxed
 PORTVERSION=	1.1.5
+PORTREVISION=	1
 CATEGORIES=	devel python
 MASTER_SITES=	CHEESESHOP
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
@@ -12,7 +13,7 @@ LICENSE_FILE=	${WRKSRC}/LICENSE
 
 RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}pytest>=3,<5:devel/py-pytest@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}six>=1,<2:devel/py-six@${PY_FLAVOR} \
-		${PYTHON_PKGNAMEPREFIX}decorator>=4,<5:devel/py-decorator@${PY_FLAVOR}
+		${PYTHON_PKGNAMEPREFIX}decorator4>=4,<5:devel/py-decorator@${PY_FLAVOR}
 
 USES=		python:3.6+
 USE_PYTHON=	autoplist distutils

--- a/multimedia/py-moviepy/Makefile
+++ b/multimedia/py-moviepy/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	moviepy
 PORTVERSION=	1.0.3
+PORTREVISION=	1
 CATEGORIES=	multimedia python
 MASTER_SITES=	CHEESESHOP
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
@@ -11,7 +12,7 @@ LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/LICENCE.txt
 
 RUN_DEPENDS=	ffmpeg:multimedia/ffmpeg \
-		${PYTHON_PKGNAMEPREFIX}decorator>=4.0.2<5.0:devel/py-decorator@${PY_FLAVOR} \
+		${PYTHON_PKGNAMEPREFIX}decorator4>=4.0.2<5.0:devel/py-decorator@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}imageio>=2.5<3.0:graphics/py-imageio@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}imageio-ffmpeg>=0.2.0:graphics/py-imageio-ffmpeg@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}numpy>=0,1:math/py-numpy@${PY_FLAVOR} \


### PR DESCRIPTION
devel/py-decorator needs to be updated to 5.x, while some ports don't
support that in their latest releases, including:

- devel/py-pytest-relaxed
- multimedia/py-moviepy

Updated them to use this devel/py-decorator4 until they officially
support 5.x. No functional changes for these ports.

Approved by:	lwhsu (mentor), portmgr (implicit, no functional change)