### PR TITLE
devel/R-cran-pkgcache: New port

### DIFF
--- a/devel/Makefile
+++ b/devel/Makefile
@@ -67,6 +67,7 @@
     SUBDIR += R-cran-optparse
     SUBDIR += R-cran-pillar
     SUBDIR += R-cran-pkgbuild
+    SUBDIR += R-cran-pkgcache
     SUBDIR += R-cran-pkgconfig
     SUBDIR += R-cran-pkgload
     SUBDIR += R-cran-pkgmaker

--- a/devel/R-cran-pkgcache/Makefile
+++ b/devel/R-cran-pkgcache/Makefile
@@ -1,0 +1,40 @@
+# Created by: Guangyuan Yang <ygy@FreeBSD.org>
+
+PORTNAME=	pkgcache
+DISTVERSION=	1.2.2
+CATEGORIES=	devel
+DISTNAME=	${PORTNAME}_${DISTVERSION}
+
+MAINTAINER=	ygy@FreeBSD.org
+COMMENT=	Cache 'CRAN'-Like Metadata and R Packages
+
+LICENSE=	MIT
+LICENSE_FILE=	${WRKSRC}/LICENSE
+
+RUN_DEPENDS=	R-cran-jsonlite>0:converters/R-cran-jsonlite \
+		R-cran-R6>0:devel/R-cran-R6 \
+		R-cran-callr>=2.0.4.9000:devel/R-cran-callr \
+		R-cran-cli>=2.0.0:devel/R-cran-cli \
+		R-cran-filelock>0:devel/R-cran-filelock \
+		R-cran-glue>0:devel/R-cran-glue \
+		R-cran-prettyunits>0:devel/R-cran-prettyunits \
+		R-cran-rappdirs>0:devel/R-cran-rappdirs \
+		R-cran-rlang>0:devel/R-cran-rlang \
+		R-cran-tibble>0:devel/R-cran-tibble \
+		R-cran-uuid>0:devel/R-cran-uuid \
+		R-cran-curl>=3.2:ftp/R-cran-curl \
+		R-cran-assertthat>0:math/R-cran-assertthat \
+		R-cran-digest>0:security/R-cran-digest \
+		R-cran-processx>=3.3.0.9001:sysutils/R-cran-processx
+TEST_DEPENDS=	R-cran-covr>0:devel/R-cran-covr \
+		R-cran-desc>0:devel/R-cran-desc \
+		R-cran-mockery>0:devel/R-cran-mockery \
+		R-cran-rprojroot>0:devel/R-cran-rprojroot \
+		R-cran-sessioninfo>0:devel/R-cran-sessioninfo \
+		R-cran-testthat>0:devel/R-cran-testthat \
+		R-cran-withr>0:devel/R-cran-withr \
+		R-cran-fs>0:sysutils/R-cran-fs
+
+USES=		cran:auto-plist
+
+.include <bsd.port.mk>

--- a/devel/R-cran-pkgcache/distinfo
+++ b/devel/R-cran-pkgcache/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1621841243
+SHA256 (pkgcache_1.2.2.tar.gz) = 9d707fbfc0f461fdc47cd02a79af2670a9fafcc1d5d26d7564564fdc75f8e34b
+SIZE (pkgcache_1.2.2.tar.gz) = 164094

--- a/devel/R-cran-pkgcache/pkg-descr
+++ b/devel/R-cran-pkgcache/pkg-descr
@@ -1,0 +1,5 @@
+Metadata and package cache for CRAN-like repositories. This is a utility
+package to be used by package management tools that want to take advantage of
+caching.
+
+WWW: https://github.com/r-lib/pkgcache#readme


### PR DESCRIPTION
Cache 'CRAN'-Like Metadata and R Packages

Approved by:	lwhsu (mentor, implicit)