### PR TITLE
security/crlfuzz: New port: Fast tool to scan CRLF vulnerability

### DIFF
--- a/security/Makefile
+++ b/security/Makefile
@@ -101,6 +101,7 @@
     SUBDIR += cracklib
     SUBDIR += crackpkcs12
     SUBDIR += create-cert
+    SUBDIR += crlfuzz
     SUBDIR += crowdsec
     SUBDIR += crowdsec-firewall-bouncer
     SUBDIR += cryptlib

--- a/security/crlfuzz/Makefile
+++ b/security/crlfuzz/Makefile
@@ -1,0 +1,26 @@
+# Created by: Gabriel M. Dutra <0xdutra@gmail.com>
+
+PORTNAME=	crlfuzz
+PORTVERSION=	1.4.1
+DISTVERSIONPREFIX=	v
+CATEGORIES=	security
+
+MAINTAINER=	0xdutra@gmail.com
+COMMENT=	Fast tool to scan CRLF vulnerability written in Go
+
+LICENSE=	MIT
+LICENSE_FILE=	${WRKSRC}/LICENSE
+
+USES=	go:modules
+
+USE_GITHUB=	yes
+GH_ACCOUNT=	dwisiswant0
+
+GO_TARGET=	./cmd/crlfuzz
+
+GH_TUPLE=	logrusorgru:aurora:e9ef32dff381:logrusorgru_aurora/vendor/github.com/logrusorgru/aurora \
+		projectdiscovery:gologger:v1.0.1:projectdiscovery_gologger/vendor/github.com/projectdiscovery/gologger
+
+PLIST_FILES=	bin/${PORTNAME}
+
+.include <bsd.port.mk>

--- a/security/crlfuzz/distinfo
+++ b/security/crlfuzz/distinfo
@@ -1,0 +1,7 @@
+TIMESTAMP = 1621033411
+SHA256 (dwisiswant0-crlfuzz-v1.4.1_GH0.tar.gz) = 7ef3ea3890b501aab1507e2fd53cc6390cebafc6dbce5efca1faf03b967db8a3
+SIZE (dwisiswant0-crlfuzz-v1.4.1_GH0.tar.gz) = 13644
+SHA256 (logrusorgru-aurora-e9ef32dff381_GH0.tar.gz) = d44d7e14a643fa4711658a520c6946ae33761e3c580f9d3c842b0b487d0472a6
+SIZE (logrusorgru-aurora-e9ef32dff381_GH0.tar.gz) = 133625
+SHA256 (projectdiscovery-gologger-v1.0.1_GH0.tar.gz) = 4a5b2cf9df762cf652325c7f7c48b27a7515581bd3d65bf8b8664a00f482a7d4
+SIZE (projectdiscovery-gologger-v1.0.1_GH0.tar.gz) = 3546

--- a/security/crlfuzz/pkg-descr
+++ b/security/crlfuzz/pkg-descr
@@ -1,0 +1,3 @@
+Fast tool to scan CRLF vulnerability written in Go.
+
+WWW: https://github.com/dwisiswant0/crlfuzz


### PR DESCRIPTION
PR:		255888
Submitted by:	Gabriel Dutra <0xdutra@gmail.com>
Approved by:	lwhsu (mentor)