### PR TITLE
devel/magit-popup: Mark DEPRECATED and set EXPIRATION_DATE

### DIFF
--- a/devel/magit-popup/Makefile
+++ b/devel/magit-popup/Makefile
@@ -11,6 +11,9 @@ COMMENT=	Define prefix-infix-suffix command combos
 LICENSE=	GPLv3+
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
+DEPRECATED=		No consumer in the ports tree any more.
+EXPIRATION_DATE=	2021-08-31
+
 BUILD_DEPENDS=	dash.el${EMACS_PKGNAMESUFFIX}>=2.12.1:devel/dash.el@${EMACS_FLAVOR}
 RUN_DEPENDS=	dash.el${EMACS_PKGNAMESUFFIX}>=2.12.1:devel/dash.el@${EMACS_FLAVOR}
 


### PR DESCRIPTION
After devel/magit has been updated to 3.0.0, there is no consumer of
this port in the ports tree, so mark it DEPRECATED and set EXPIRATION_DATE.

PR:		256155
Submitted by:	Yasuhiro Kimura <yasu@utahime.org> (maintainer)
Approved by:	lwhsu (mentor)