### PR TITLE
science/orthanc-mysql: New port

### DIFF
--- a/science/Makefile
+++ b/science/Makefile
@@ -177,6 +177,7 @@
     SUBDIR += opensph
     SUBDIR += opsin
     SUBDIR += orthanc
+    SUBDIR += orthanc-mysql
     SUBDIR += orthanc-webviewer
     SUBDIR += p5-Algorithm-SVMLight
     SUBDIR += p5-Chemistry-3DBuilder

--- a/science/orthanc-mysql/Makefile
+++ b/science/orthanc-mysql/Makefile
@@ -1,0 +1,48 @@
+# Created by: maintainer.freebsd@xpoundit.com
+
+PORTNAME=	orthanc-mysql
+DISTVERSION=	4.0
+CATEGORIES=	science
+MASTER_SITES=	https://www.orthanc-server.com/downloads/get.php?path=/plugin-mysql/:main \
+		https://www.orthanc-server.com/downloads/get.php?path=/orthanc/:framework \
+		https://orthanc.osimis.io/ThirdPartyDownloads/:thirdparty
+DISTFILES=	OrthancMySQL-${PORTVERSION}.tar.gz:main \
+		Orthanc-1.9.3.tar.gz:framework \
+		e2fsprogs-1.44.5.tar.gz:thirdparty
+DIST_SUBDIR=	orthanc
+EXTRACT_ONLY=	OrthancMySQL-${PORTVERSION}.tar.gz
+
+MAINTAINER=	maintainer.freebsd@xpoundit.com
+COMMENT=	Orthanc plugin to use MySQL/MariaDB for indexing or storage
+
+LICENSE=	AGPLv3
+LICENSE_FILE=	${WRKSRC}/COPYING
+
+BUILD_DEPENDS=	${LOCALBASE}/include/orthanc/OrthancCDatabasePlugin.h:science/orthanc
+LIB_DEPENDS=	libboost_filesystem.so:devel/boost-libs \
+		libcurl.so:ftp/curl \
+		libgdcmCommon.so:devel/gdcm \
+		libjsoncpp.so:devel/jsoncpp \
+		libpugixml.so:textproc/pugixml
+RUN_DEPENDS=	Orthanc:science/orthanc
+
+USES=		cmake localbase mysql:client python:build ssl
+USE_LDCONFIG=	yes
+
+WRKSRC=		${WRKDIR}/OrthancMySQL-${PORTVERSION}
+CMAKE_SOURCE_PATH=	${WRKSRC}/MySQL
+CMAKE_OFF=	DBUILD_UNIT_TESTS USE_SYSTEM_ORTHANC_SDK USE_SYSTEM_UUID
+CMAKE_ARGS=	-DORTHANC_FRAMEWORK_ROOT=${WRKSRC}/MySQL/ThirdPartyDownloads/Orthanc-1.9.3/OrthancFramework/Sources \
+		-DORTHANC_FRAMEWORK_SOURCE=path
+CXXFLAGS+=	-I${LOCALBASE}/include -DNDEBUG
+CFLAGS+=	-DORTHANC_ENABLE_LOGGING_PLUGIN -DNDEBUG
+
+PLIST_SUB=	DISTVERSION=${DISTVERSION}
+
+post-extract:
+		${MKDIR} ${WRKSRC}/MySQL/ThirdPartyDownloads
+		${CP} ${DISTDIR}/${DIST_SUBDIR}/e2fsprogs-1.44.5.tar.gz ${WRKSRC}/MySQL/ThirdPartyDownloads
+		${CP} ${DISTDIR}/${DIST_SUBDIR}/Orthanc-1.9.3.tar.gz ${WRKSRC}/MySQL/ThirdPartyDownloads
+		${TAR} -C ${WRKSRC}/MySQL/ThirdPartyDownloads -xf ${WRKSRC}/MySQL/ThirdPartyDownloads/Orthanc-1.9.3.tar.gz
+
+.include <bsd.port.mk>

--- a/science/orthanc-mysql/distinfo
+++ b/science/orthanc-mysql/distinfo
@@ -1,0 +1,7 @@
+TIMESTAMP = 1620905033
+SHA256 (orthanc/OrthancMySQL-4.0.tar.gz) = 9420b7d3293768778fc4f60cc7d72c0e15c1287bead98f6c3a9beddf6865a09a
+SIZE (orthanc/OrthancMySQL-4.0.tar.gz) = 318342
+SHA256 (orthanc/Orthanc-1.9.3.tar.gz) = 41cc35a3d15ecb0d7b834e8e28a740cc4ffa1f333c019a764228d60e96608960
+SIZE (orthanc/Orthanc-1.9.3.tar.gz) = 1818313
+SHA256 (orthanc/e2fsprogs-1.44.5.tar.gz) = 2e211fae27ef74d5af4a4e40b10b8df7f87c655933bd171aab4889bfc4e6d1cc
+SIZE (orthanc/e2fsprogs-1.44.5.tar.gz) = 7619237

--- a/science/orthanc-mysql/pkg-descr
+++ b/science/orthanc-mysql/pkg-descr
@@ -1,0 +1,5 @@
+Orthanc-mysql is an Orthanc plugin that replaces the default SQLite
+engine of Orthanc with a MySQL back-end. The plugin is compatible
+with MariaDB as well.
+
+WWW: https://www.orthanc-server.com/static.php?page=mysql

--- a/science/orthanc-mysql/pkg-plist
+++ b/science/orthanc-mysql/pkg-plist
@@ -1,0 +1,4 @@
+share/orthanc/plugins/libOrthancMySQLIndex.so
+share/orthanc/plugins/libOrthancMySQLIndex.so.%%DISTVERSION%%
+share/orthanc/plugins/libOrthancMySQLStorage.so
+share/orthanc/plugins/libOrthancMySQLStorage.so.%%DISTVERSION%%


### PR DESCRIPTION
Orthanc plugin to use MySQL or MariaDB for indexing or storage.

PR:		242552
Approved by:	lwhsu (mentor)