### PR TITLE
net-mgmt/netdata-go: Update to 0.29.0

### DIFF
--- a/net-mgmt/netdata-go/Makefile
+++ b/net-mgmt/netdata-go/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	netdata-go
 DISTVERSIONPREFIX=	v
-DISTVERSION=	0.28.1
+DISTVERSION=	0.29.0
 CATEGORIES=	net-mgmt
 
 MAINTAINER=	driesm.michiels@gmail.com

--- a/net-mgmt/netdata-go/distinfo
+++ b/net-mgmt/netdata-go/distinfo
@@ -1,5 +1,5 @@
-TIMESTAMP = 1616858885
-SHA256 (go/net-mgmt_netdata-go/netdata-go-v0.28.1/v0.28.1.mod) = d6b5914b94034fd08cf64ad852dd803abfd5c469b1e15878a86f502c5e530122
-SIZE (go/net-mgmt_netdata-go/netdata-go-v0.28.1/v0.28.1.mod) = 1403
-SHA256 (go/net-mgmt_netdata-go/netdata-go-v0.28.1/v0.28.1.zip) = c72a1fc05eab93fa274c7230b00487f26cc653b0813862b68c4d78a8ea79ed48
-SIZE (go/net-mgmt_netdata-go/netdata-go-v0.28.1/v0.28.1.zip) = 1223024
+TIMESTAMP = 1624096055
+SHA256 (go/net-mgmt_netdata-go/netdata-go-v0.29.0/v0.29.0.mod) = 0a218a3372b5db6039974f6ca24444d12954b41f6a9b90837dcf7e4d90b58237
+SIZE (go/net-mgmt_netdata-go/netdata-go-v0.29.0/v0.29.0.mod) = 1463
+SHA256 (go/net-mgmt_netdata-go/netdata-go-v0.29.0/v0.29.0.zip) = 71c4d13e1475ca4e9d398ce4896211e616efa8d99a9d76ee85f354b4ee023bcb
+SIZE (go/net-mgmt_netdata-go/netdata-go-v0.29.0/v0.29.0.zip) = 1225457


### PR DESCRIPTION
Changes:	https://github.com/netdata/go.d.plugin/releases/tag/v0.29.0

PR:		256710
Approved by:	lwhsu (mentor, implicit)