### PR TITLE
biology/jalview: Fix build

### DIFF
--- a/biology/jalview/Makefile
+++ b/biology/jalview/Makefile
@@ -16,7 +16,7 @@ LICENSE_FILE=	${WRKSRC}/LICENSE
 
 BROKEN_FreeBSD_11=	gradle daemon systematically fails on 11: The message received from the daemon indicates that the daemon has disappeared.
 
-BUILD_DEPENDS=	gradle6:devel/gradle6
+BUILD_DEPENDS=	gradle:devel/gradle6
 
 USE_JAVA=	yes
 JAVA_VERSION=	11
@@ -61,7 +61,7 @@ PLIST_FILES=	bin/jalview \
 		${DATADIR}/jalview.jar
 
 do-build:
-	@cd ${WRKSRC} && ${SETENV} ${MAKE_ENV} gradle6 \
+	@cd ${WRKSRC} && ${SETENV} ${MAKE_ENV} gradle \
 		--gradle-user-home ${DEPS_CACHE_DIR}/gradle-${PORTNAME} --project-cache-dir ${DEPS_CACHE_DIR}/gradle-${PORTNAME} \
 		${GRADLE_ARGS} --build-cache shadowJar
 


### PR DESCRIPTION
When switching the build dependency from devel/gradle to devel/gradle6,
the build is accidentally broken. This attempts to revert part of the
change and fix build.

Fixes:		55044a2200a4c42b6b653349f0a65dfca3f96f36
Approved by:	lwhsu (mentor, implicit), portmgr (fix build)