### PR TITLE
devel/py-backports.zoneinfo: New port

### DIFF
--- a/devel/Makefile
+++ b/devel/Makefile
@@ -4202,6 +4202,7 @@
     SUBDIR += py-backcall
     SUBDIR += py-backports
     SUBDIR += py-backports.csv
+    SUBDIR += py-backports.zoneinfo
     SUBDIR += py-banal
     SUBDIR += py-bandit
     SUBDIR += py-bcdoc

--- a/devel/py-backports.zoneinfo/Makefile
+++ b/devel/py-backports.zoneinfo/Makefile
@@ -1,0 +1,16 @@
+PORTNAME=	backports.zoneinfo
+DISTVERSION=	0.2.1
+CATEGORIES=	devel python
+MASTER_SITES=	CHEESESHOP
+PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
+
+MAINTAINER=	ygy@FreeBSD.org
+COMMENT=	Backport of the standard library module zoneinfo
+
+LICENSE=	APACHE20
+LICENSE_FILE=	${WRKSRC}/LICENSE
+
+USES=		python:3.7+
+USE_PYTHON=	autoplist concurrent distutils
+
+.include <bsd.port.mk>

--- a/devel/py-backports.zoneinfo/distinfo
+++ b/devel/py-backports.zoneinfo/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1624723154
+SHA256 (backports.zoneinfo-0.2.1.tar.gz) = fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2
+SIZE (backports.zoneinfo-0.2.1.tar.gz) = 74098

--- a/devel/py-backports.zoneinfo/pkg-descr
+++ b/devel/py-backports.zoneinfo/pkg-descr
@@ -1,0 +1,11 @@
+This package was originally the reference implementation for PEP 615,
+which proposes support for the IANA time zone database in the standard
+library, and now serves as a backport to Python 3.6+ (including PyPy).
+
+This exposes the backports.zoneinfo module, which is a backport of the
+zoneinfo module. The backport's documentation can be found on readthedocs.
+
+The module uses the system time zone data if available, and falls back
+to the tzdata package (available on PyPI) if installed.
+
+WWW: https://github.com/pganssle/zoneinfo


### PR DESCRIPTION
Backport of the standard library module zoneinfo.

PR:		256883
Submitted by:	rozhuk.im@gmail.com
Approved by:	lwhsu (mentor)