### PR TITLE
sysutils/bastille: Update to 0.9.20210714

### DIFF
--- a/sysutils/bastille/Makefile
+++ b/sysutils/bastille/Makefile
@@ -1,7 +1,7 @@
 # Created by: Christer Edwards <christer.edwards@gmail.com>
 
 PORTNAME=	bastille
-PORTVERSION=	0.8.20210115
+PORTVERSION=	0.9.20210714
 CATEGORIES=	sysutils
 
 MAINTAINER=	christer.edwards@gmail.com
@@ -12,7 +12,7 @@ LICENSE_FILE=	${WRKSRC}/LICENSE
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	bastillebsd
-GH_TAGNAME=	113beb5
+GH_TAGNAME=	cc60df5
 
 NO_BUILD=	yes
 NO_ARCH=	yes

--- a/sysutils/bastille/distinfo
+++ b/sysutils/bastille/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1610768540
-SHA256 (bastillebsd-bastille-0.8.20210115-113beb5_GH0.tar.gz) = 98a01eeda9ae051248ab69b6a0f6ac022cbb30f73745c83d00d0a4a906f48f07
-SIZE (bastillebsd-bastille-0.8.20210115-113beb5_GH0.tar.gz) = 573482
+TIMESTAMP = 1626310397
+SHA256 (bastillebsd-bastille-0.9.20210714-cc60df5_GH0.tar.gz) = 43d8667144f201bb50778b9fa88e71a162da749683b95af20bd698388963b615
+SIZE (bastillebsd-bastille-0.9.20210714-cc60df5_GH0.tar.gz) = 579431

--- a/sysutils/bastille/pkg-plist
+++ b/sysutils/bastille/pkg-plist
@@ -29,6 +29,7 @@ bin/bastille
 %%DATADIR%%/template.sh
 %%DATADIR%%/templates/default/base/Bastillefile
 %%DATADIR%%/templates/default/empty/Bastillefile
+%%DATADIR%%/templates/default/linux/Bastillefile
 %%DATADIR%%/templates/default/thick/Bastillefile
 %%DATADIR%%/templates/default/thin/Bastillefile
 %%DATADIR%%/templates/default/vnet/Bastillefile


### PR DESCRIPTION
Changes:	https://github.com/BastilleBSD/bastille/releases/tag/0.9.20210714

PR:		257196