### PR TITLE
devel/py-thriftpy2: New port: Pure python implementation of Apache Thrift

### DIFF
--- a/devel/Makefile
+++ b/devel/Makefile
@@ -5192,6 +5192,7 @@
     SUBDIR += py-threema-msgapi
     SUBDIR += py-thrift
     SUBDIR += py-thriftpy
+    SUBDIR += py-thriftpy2
     SUBDIR += py-tiamat
     SUBDIR += py-timelib
     SUBDIR += py-tinyarray

--- a/devel/py-thriftpy2/Makefile
+++ b/devel/py-thriftpy2/Makefile
@@ -1,0 +1,19 @@
+# Created by: Guangyuan Yang <ygy@FreeBSD.org>
+
+PORTNAME=	thriftpy2
+DISTVERSION=	0.4.14
+CATEGORIES=	devel python
+MASTER_SITES=	CHEESESHOP
+PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
+
+MAINTAINER=	ygy@FreeBSD.org
+COMMENT=	Pure python implementation of Apache Thrift
+
+LICENSE=	MIT
+
+USES=		python
+USE_PYTHON=	autoplist distutils
+
+NO_ARCH=	yes
+
+.include <bsd.port.mk>

--- a/devel/py-thriftpy2/distinfo
+++ b/devel/py-thriftpy2/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1626928084
+SHA256 (thriftpy2-0.4.14.tar.gz) = 1758ccaeb2a40d8779b50cdd3d7a3b43e8c5752f21ad0a54ded7c251d05219e8
+SIZE (thriftpy2-0.4.14.tar.gz) = 361668

--- a/devel/py-thriftpy2/pkg-descr
+++ b/devel/py-thriftpy2/pkg-descr
@@ -1,0 +1,5 @@
+ThriftPy2 is a pure python implementation of Apache Thrift in a pythonic
+way. It is fully compatible to ThriftPy and aims to provide long-term
+support.
+
+WWW: https://github.com/Thriftpy/thriftpy2


### PR DESCRIPTION
Approved by:	lwhsu (mentor, implicit)