### PR TITLE
databases/mongodb50: Update to 5.0.1

### DIFF
--- a/databases/mongodb50/Makefile
+++ b/databases/mongodb50/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	mongodb
 DISTVERSIONPREFIX=	r
-DISTVERSION=	5.0.0-rc1
+DISTVERSION=	5.0.1
 CATEGORIES=	databases net
 MASTER_SITES=	https://fastdl.mongodb.org/src/ \
 		http://fastdl.mongodb.org/src/

--- a/databases/mongodb50/distinfo
+++ b/databases/mongodb50/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1623670264
-SHA256 (mongodb-src-r5.0.0-rc1.tar.gz) = 17b4998385e82855bb6a17056ae75e1811c2784c14b6ba89706f0ad17f5279dc
-SIZE (mongodb-src-r5.0.0-rc1.tar.gz) = 54409236
+TIMESTAMP = 1626811181
+SHA256 (mongodb-src-r5.0.1.tar.gz) = 141c9a6b538e121b2d69e26b9b3e7308f24dff9c7c238190233204a2ebe39b83
+SIZE (mongodb-src-r5.0.1.tar.gz) = 54468206

--- a/databases/mongodb50/files/patch-SConstruct
+++ b/databases/mongodb50/files/patch-SConstruct
@@ -1,6 +1,6 @@
---- SConstruct.orig	2021-04-29 23:06:52 UTC
+--- SConstruct.orig	2021-07-15 20:56:31 UTC
 +++ SConstruct
-@@ -1324,9 +1324,9 @@ if has_option('variables-help'):
+@@ -1328,9 +1328,9 @@ if has_option('variables-help'):
      print(env_vars.GenerateHelpText(env))
      Exit(0)
  
@@ -13,7 +13,7 @@
  
  if get_option('install-action') != 'default' and get_option('ninja') != "disabled":
      env.FatalError("Cannot use non-default install actions when generating Ninja.")
-@@ -2498,7 +2498,7 @@ if env.TargetOSIs('posix'):
+@@ -2507,7 +2507,7 @@ if env.TargetOSIs('posix'):
              # If runtime hardening is requested, then build anything
              # destined for an executable with the necessary flags for PIE.
              env.AppendUnique(
@@ -22,7 +22,7 @@
                  PROGLINKFLAGS=['-pie'],
              )
  
-@@ -2675,8 +2675,12 @@ if not env.TargetOSIs('windows') and (env.ToolchainIs(
+@@ -2684,8 +2684,12 @@ if not env.TargetOSIs('windows', 'macOS') and (env.Too
      # setting it for both C and C++ by setting both of CFLAGS and
      # CXXFLAGS.
  
@@ -36,3 +36,13 @@
          "i386"       : { "-march=" : "nocona",       "-mtune=" : "generic"                        },
          "ppc64le"    : { "-mcpu="  : "power8",       "-mtune=" : "power8", "-mcmodel=" : "medium" },
          "s390x"      : { "-march=" : "z196",         "-mtune=" : "zEC12"                          },
+@@ -4520,7 +4524,8 @@ def doConfigure(myenv):
+     myenv = conf.Finish()
+ 
+     if env['TARGET_ARCH'] == "aarch64":
+-        AddToCCFLAGSIfSupported(myenv, "-moutline-atomics")
++        # https://lists.freebsd.org/archives/freebsd-ports/2021-July/000431.html
++        AddToCCFLAGSIfSupported(myenv, "-mno-outline-atomics")
+ 
+     conf = Configure(myenv)
+     usdt_enabled = get_option('enable-usdt-probes')


### PR DESCRIPTION
- Add a fix for compilation on aarch64 on 14-CURRENT/clang 12.
See: https://lists.freebsd.org/archives/freebsd-ports/2021-July/000431.html

Changelog:	https://docs.mongodb.com/manual/release-notes/5.0-changelog/#5.0.1-changelog

PR:		257394
Approved by:	lwhsu (mentor, implicit)