### PR TITLE
databases/galera26: Update to 26.4.9

### DIFF
--- a/databases/galera26/Makefile
+++ b/databases/galera26/Makefile
@@ -1,9 +1,8 @@
 # Created by: Nicolas Embriz <nbari@tequila.io>
 
 PORTNAME=	galera
-PORTVERSION=	26.4.8
+PORTVERSION=	26.4.9
 DISTVERSIONPREFIX=	release_
-PORTREVISION=	1
 CATEGORIES=	databases
 PKGNAMESUFFIX=	26
 

--- a/databases/galera26/distinfo
+++ b/databases/galera26/distinfo
@@ -1,5 +1,5 @@
-TIMESTAMP = 1617278996
-SHA256 (codership-galera-release_26.4.8_GH0.tar.gz) = c7669b3a3594c6db2f7b793d7cb455e7ccb71b15f699efe5db4af472b685b7ea
-SIZE (codership-galera-release_26.4.8_GH0.tar.gz) = 3489437
+TIMESTAMP = 1627382288
+SHA256 (codership-galera-release_26.4.9_GH0.tar.gz) = d920ff3eb902f9b05534edfb4fabd57e6a355845ca271e48d6b37f9e380f545e
+SIZE (codership-galera-release_26.4.9_GH0.tar.gz) = 3490784
 SHA256 (codership-wsrep-API-76cf223c690845bbf561cb820a46e06a18ad80d1_GH0.tar.gz) = 214fb8701ae51bcdf8171475a93f2c28ddd56e642feb172ec5148b4d3c73d4a6
 SIZE (codership-wsrep-API-76cf223c690845bbf561cb820a46e06a18ad80d1_GH0.tar.gz) = 90155


### PR DESCRIPTION
Changelog:	http://releases.galeracluster.com/galera-4.9/release-notes-galera-26.4.9.txt

PR:		257453
Approved by:	lwhsu (mentor, implicit)