### PR TITLE
dns/powerdns-recursor: Update to 4.5.5

### DIFF
--- a/dns/powerdns-recursor/Makefile
+++ b/dns/powerdns-recursor/Makefile
@@ -1,7 +1,7 @@
 # Created by: sten@blinkenlights.nl
 
 PORTNAME=	recursor
-DISTVERSION=	4.5.4
+DISTVERSION=	4.5.5
 CATEGORIES=	dns
 MASTER_SITES=	http://downloads.powerdns.com/releases/
 PKGNAMEPREFIX=	powerdns-

--- a/dns/powerdns-recursor/distinfo
+++ b/dns/powerdns-recursor/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1625221061
-SHA256 (pdns-recursor-4.5.4.tar.bz2) = 015d606a8f9a4a711489634d57375c77cc34f999ca43c195d8002e31a747896a
-SIZE (pdns-recursor-4.5.4.tar.bz2) = 1466655
+TIMESTAMP = 1627656397
+SHA256 (pdns-recursor-4.5.5.tar.bz2) = a836a39b99fcc21873e4ba3a60aa9915a33fac7b44922696e9a257f551fe05fb
+SIZE (pdns-recursor-4.5.5.tar.bz2) = 1472089


### PR DESCRIPTION
Changelog:	https://blog.powerdns.com/2021/07/30/powerdns-recursor-4-4-5-and-4-5-5-released/

PR:		257581