### PR TITLE
devel/rubygem-oci: Update to 2.15.0

### DIFF
--- a/devel/rubygem-oci/Makefile
+++ b/devel/rubygem-oci/Makefile
@@ -1,7 +1,7 @@
 # Created by: Alessandro Sagratini <ale_sagra@hotmail.com>
 
 PORTNAME=	oci
-DISTVERSION=	2.14.0
+DISTVERSION=	2.15.0
 CATEGORIES=	devel rubygems
 MASTER_SITES=	RG
 

--- a/devel/rubygem-oci/distinfo
+++ b/devel/rubygem-oci/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1622019969
-SHA256 (rubygem/oci-2.14.0.gem) = c91b8f2c9639b31f756dfaafe8f74e7bc1e5af3a0eaa0e06194f69a0cdd3db96
-SIZE (rubygem/oci-2.14.0.gem) = 3784704
+TIMESTAMP = 1628030929
+SHA256 (rubygem/oci-2.15.0.gem) = bd320efc8a2e936fc768e23e6f143d4a5b673cf3879958792e0b393219846b86
+SIZE (rubygem/oci-2.15.0.gem) = 4150272


### PR DESCRIPTION
Changelog:	https://github.com/oracle/oci-ruby-sdk/releases/tag/v2.15.0

PR:		257598