### PR TITLE
comms/py-fritzconnection: New port

### DIFF
--- a/comms/Makefile
+++ b/comms/Makefile
@@ -132,6 +132,7 @@
     SUBDIR += predict
     SUBDIR += py-adafruit-ampy
     SUBDIR += py-esptool
+    SUBDIR += py-fritzconnection
     SUBDIR += py-hid
     SUBDIR += py-hidapi
     SUBDIR += py-libimobiledevice

--- a/comms/py-fritzconnection/Makefile
+++ b/comms/py-fritzconnection/Makefile
@@ -1,0 +1,25 @@
+PORTNAME=	fritzconnection
+DISTVERSION=	1.6.0
+CATEGORIES=	comms python
+PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
+
+MAINTAINER=	freebsd@michael-bueker.de
+COMMENT=	Python tool to communicate with AVM FritzBox routers
+
+LICENSE=	MIT
+LICENSE_FILE=	${WRKSRC}/LICENSE.txt
+
+RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}requests>=2.22.0:www/py-requests@${PY_FLAVOR}
+TEST_DEPENDS=	${PYTHON_PKGNAMEPREFIX}pytest>=0:devel/py-pytest@${PY_FLAVOR}
+
+USES=		python
+USE_PYTHON=	autoplist distutils
+NO_ARCH=	yes
+
+USE_GITHUB=	yes
+GH_ACCOUNT=	kbr
+
+do-test:
+	@cd ${WRKSRC} && ${PYTHON_CMD} -m pytest
+
+.include <bsd.port.mk>

--- a/comms/py-fritzconnection/distinfo
+++ b/comms/py-fritzconnection/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1628255923
+SHA256 (kbr-fritzconnection-1.6.0_GH0.tar.gz) = 8ef7bea2d892dc7070c6ed6ca7d1c5649e1277ad1b07a85e49e4f57f8b5f6493
+SIZE (kbr-fritzconnection-1.6.0_GH0.tar.gz) = 73672

--- a/comms/py-fritzconnection/pkg-descr
+++ b/comms/py-fritzconnection/pkg-descr
@@ -1,0 +1,4 @@
+A Python tool to communicate with the AVM FritzBox family of home routers.
+It uses the TR-064 protocol over UPnP.
+
+WWW: https://github.com/kbr/fritzconnection/


### PR DESCRIPTION
Python tool to communicate with AVM FritzBox routers.

PR:		256989