### PR TITLE
www/grafana8: Reflect upstream LICENSE change

### DIFF
--- a/www/grafana8/Makefile
+++ b/www/grafana8/Makefile
@@ -15,7 +15,7 @@ DISTFILES=	grafana-${PORTVERSION}.linux-amd64${EXTRACT_SUFX}:public \
 MAINTAINER=	drtr0jan@yandex.ru
 COMMENT=	Dashboard and graph editor for multiple data stores
 
-LICENSE=	APACHE20
+LICENSE=	AGPLv3
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
 ONLY_FOR_ARCHS=	aarch64 amd64 i386


### PR DESCRIPTION
Upstream has switched the license to AGPLv3 since Grafana 8:

https://github.com/grafana/grafana/commit/8db3eb90ae8c20e1a2bbbad300e0683def9bf8fb

Reported by:	txt.file@txtfile.eu (by email)
Approved by:	portmgr (blanket)
MFH:		2021Q3