### PR TITLE
net/py-flask-xml-rpc: Mark DEPRECATED and set expiration date

### DIFF
--- a/net/py-flask-xml-rpc/Makefile
+++ b/net/py-flask-xml-rpc/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	Flask-XML-RPC
 PORTVERSION=	0.1.2
+PORTREVISION=	1
 CATEGORIES=	net python
 MASTER_SITES=	CHEESESHOP
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
@@ -9,14 +10,17 @@ COMMENT=	Adds support for creating XML-RPC APIs to Flask
 
 LICENSE=	MIT
 
+DEPRECATED=	No longer maintained upstream
+EXPIRATION_DATE=	2021-12-31
+
 RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}Flask>0:www/py-flask@${PY_FLAVOR}
 TEST_DEPENDS=	${PYTHON_PKGNAMEPREFIX}nose>0:devel/py-nose@${PY_FLAVOR}
-
-NO_ARCH=	yes
 
 # 2.7,3.4+
 USES=		python:3.6+
 USE_PYTHON=	autoplist distutils
+
+NO_ARCH=	yes
 
 do-test:
 	@cd ${WRKSRC} && ${PYTHON_CMD} ${PYDISTUTILS_SETUP} test

--- a/net/py-flask-xml-rpc/pkg-descr
+++ b/net/py-flask-xml-rpc/pkg-descr
@@ -3,4 +3,4 @@ based on the XML-RPC standard. It features easy registration of methods
 and namespacing, connects seamlessly to your Flask app, and includes
 plenty of testing helpers.
 
-WWW: https://bitbucket.org/leafstorm/flask-xml-rpc/
+WWW: https://pythonhosted.org/Flask-XML-RPC/


### PR DESCRIPTION
This port is no longer maintained upstream. Mark DEPRECATED after the
next quarterly cycle. Also:

- Replace 404 WWW with link to documentation site
- Pet portlint

PR:		257847