### PR TITLE
lang/go: Update to 1.17.3

### DIFF
--- a/lang/go/Makefile
+++ b/lang/go/Makefile
@@ -1,7 +1,7 @@
 # Created by: Devon H. O'Dell <devon.odell@gmail.com>
 
 PORTNAME=	go
-PORTVERSION?=	1.17.2
+PORTVERSION?=	1.17.3
 PORTREVISION?=	0
 PORTEPOCH?=	1
 CATEGORIES=	lang

--- a/lang/go/distinfo
+++ b/lang/go/distinfo
@@ -1,6 +1,6 @@
-TIMESTAMP = 1633671306
-SHA256 (go1.17.2.src.tar.gz) = 2255eb3e4e824dd7d5fcdc2e7f84534371c186312e546fb1086a34c17752f431
-SIZE (go1.17.2.src.tar.gz) = 22182111
+TIMESTAMP = 1636097782
+SHA256 (go1.17.3.src.tar.gz) = 705c64251e5b25d5d55ede1039c6aa22bea40a7a931d14c370339853643c3df0
+SIZE (go1.17.3.src.tar.gz) = 22183309
 SHA256 (go-freebsd-arm64-go1.14.tar.xz) = f8b0cf0d323e581c9e3e0d5c217847a3e0294fcc92dbac92a5b02cea9d97ad8d
 SIZE (go-freebsd-arm64-go1.14.tar.xz) = 34944548
 SHA256 (go-freebsd-amd64-go1.14.tar.xz) = 3b259247fb228258a4f31e283e9aa23cafd590eabce334666a9e9b2ffe47c19b


### PR DESCRIPTION
Changes:	https://golang.org/doc/devel/release#go1.17.minor
Security:	930def19-3e05-11ec-9ba8-002324b2fba8