### PR TITLE
dns/powerdns-recursor: Update to 4.5.7

### DIFF
--- a/dns/powerdns-recursor/Makefile
+++ b/dns/powerdns-recursor/Makefile
@@ -1,7 +1,7 @@
 # Created by: sten@blinkenlights.nl
 
 PORTNAME=	recursor
-DISTVERSION=	4.5.6
+DISTVERSION=	4.5.7
 CATEGORIES=	dns
 MASTER_SITES=	http://downloads.powerdns.com/releases/
 PKGNAMEPREFIX=	powerdns-

--- a/dns/powerdns-recursor/distinfo
+++ b/dns/powerdns-recursor/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1633955932
-SHA256 (pdns-recursor-4.5.6.tar.bz2) = bb89cdd3810467ed848d13cac99f6f3456bf0ddcce5f47b9d38673629ee79200
-SIZE (pdns-recursor-4.5.6.tar.bz2) = 1474500
+TIMESTAMP = 1636111352
+SHA256 (pdns-recursor-4.5.7.tar.bz2) = ad4db2d4af4630757f786f3719225c2e37481257d676803a54194c7679d07bab
+SIZE (pdns-recursor-4.5.7.tar.bz2) = 1475537


### PR DESCRIPTION
Changelog:	https://blog.powerdns.com/2021/11/05/powerdns-recursor-4-4-7-and-4-5-7-released/

PR:		259661