### PR TITLE
x11-themes/flat-remix-icon-themes: Update to 20211106

### DIFF
--- a/x11-themes/flat-remix-icon-themes/Makefile
+++ b/x11-themes/flat-remix-icon-themes/Makefile
@@ -1,7 +1,7 @@
 # Created by: Alexander Vereeken <Alexander88207@protonmail.com>
 
 PORTNAME=	flat-remix
-PORTVERSION=	20210620
+PORTVERSION=	20211106
 CATEGORIES=	x11-themes
 PKGNAMESUFFIX=	-icon-themes
 

--- a/x11-themes/flat-remix-icon-themes/distinfo
+++ b/x11-themes/flat-remix-icon-themes/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1624722885
-SHA256 (daniruiz-flat-remix-20210620_GH0.tar.gz) = 7f536657fedd9c3f7e6424b8d2ff0081132a9fa5c507e8fb205c3db12689da70
-SIZE (daniruiz-flat-remix-20210620_GH0.tar.gz) = 159508989
+TIMESTAMP = 1636987082
+SHA256 (daniruiz-flat-remix-20211106_GH0.tar.gz) = 4f794d4c71a8b5729d00aac20364ab43047560f803f9ea3f784c72c58fe22f7d
+SIZE (daniruiz-flat-remix-20211106_GH0.tar.gz) = 93561921


### PR DESCRIPTION
Changelog:	https://github.com/daniruiz/flat-remix/releases/tag/20211106

PR:		259860