### PR TITLE
archivers/advancecomp: Update to 2.1-6 and take maintainership

### DIFF
--- a/archivers/advancecomp/Makefile
+++ b/archivers/advancecomp/Makefile
@@ -1,24 +1,35 @@
 # Created by: Radim Kolar
 
 PORTNAME=	advancecomp
-PORTVERSION=	1.23
+DISTVERSIONPREFIX=	v
+DISTVERSION=	2.1-6
+DISTVERSIONSUFFIX=	-g7b08f7a
 CATEGORIES=	archivers
-MASTER_SITES=	SF/advancemame/${PORTNAME}/${PORTVERSION}
 
-MAINTAINER=	ports@FreeBSD.org
+MAINTAINER=	fuz@fuz.su
 COMMENT=	Recompression utilities for .ZIP, .PNG, .MNG, and .GZ files
 
 LICENSE=	GPLv3
 
-LIB_DEPENDS=	libzopfli.so:archivers/zopfli
+LIB_DEPENDS=	libzopfli.so:archivers/zopfli \
+		libdeflate.so:archivers/libdeflate
 
-USES=		cpe
-
+USES=		autoreconf cpe
+USE_GITHUB=	yes
+GH_ACCOUNT=	amadvance
 CPE_VENDOR=	advancemame
 
 GNU_CONFIGURE=	yes
-MAKE_ARGS=	zopfli_SOURCES="" am__objects_3=""
+TEST_TARGET=	check
+MAKE_ARGS=	zopfli_SOURCES="" am__objects_3="" \
+		libdeflate_SOURCES="" am__objects_2=""
 CPPFLAGS+=	-I${LOCALBASE}/include/zopfli
-LDFLAGS+=	-L${LOCALBASE}/lib -lzopfli
+LDFLAGS+=	-L${LOCALBASE}/lib -lzopfli -ldeflate
+
+OPTIONS_DEFINE=	BZIP2
+BZIP2_CONFIGURE_ON=	--enable-bzip2
+
+pre-test-BZIP2-on:
+	@${ECHO_MSG} Warning: test suite is known to fail with option BZIP2 enabled
 
 .include <bsd.port.mk>

--- a/archivers/advancecomp/distinfo
+++ b/archivers/advancecomp/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1479818446
-SHA256 (advancecomp-1.23.tar.gz) = 75a2c97ab0cd53e71b6a3dd7f07c001fa02351c9d781a4c586718f7fea3e88ba
-SIZE (advancecomp-1.23.tar.gz) = 1288937
+TIMESTAMP = 1636103106
+SHA256 (amadvance-advancecomp-v2.1-6-g7b08f7a_GH0.tar.gz) = d87a6b3838a0331541dd784fe5c40ec3194a5672db0b44a3fbf951cdf3cc42d9
+SIZE (amadvance-advancecomp-v2.1-6-g7b08f7a_GH0.tar.gz) = 1195162

--- a/archivers/advancecomp/files/patch-Makefile.am
+++ b/archivers/advancecomp/files/patch-Makefile.am
@@ -1,0 +1,11 @@
+--- Makefile.am.orig	2021-10-29 17:10:27 UTC
++++ Makefile.am
+@@ -332,7 +332,7 @@ check-local: ./advzip$(EXEEXT) test/test.lst
+ 	@cp $(srcdir)/test/basn2c08.png $(srcdir)/test/basn3p01.png $(srcdir)/test/basn3p02.png $(srcdir)/test/basn3p04.png $(srcdir)/test/basn3p08.png $(srcdir)/test/basn6a08.png $(srcdir)/test/basn6a04.png .
+ 	$(TESTENV) ./advpng$(EXEEXT) -f -z basn2c08.png basn3p01.png basn3p02.png basn3p04.png basn3p08.png basn6a08.png basn6a04.png
+ 	$(TESTENV) ./advpng$(EXEEXT) -L basn2c08.png basn3p01.png basn3p02.png basn3p04.png basn3p08.png basn6a08.png basn6a04.png >> check.lst
+-	cat check.lst | $(DTOU) | cmp $(srcdir)/test/test.lst
++	cat check.lst | $(DTOU) | cmp - $(srcdir)/test/test.lst
+ 	@echo Success!
+ 
+ DISTDOS_ROOT = \


### PR DESCRIPTION
- Switch to new upstream
- Unbundle libdeflate
- Hookup test suite
- Add a BZIP2 option

PR:		259534
MFH:		2021Q4 (security fix)
Security:	0bf816f6-3cfe-11ec-86cd-dca632b19f10