### PR TITLE
lang/go: Update to 1.17.5

### DIFF
--- a/lang/go/Makefile
+++ b/lang/go/Makefile
@@ -1,7 +1,7 @@
 # Created by: Devon H. O'Dell <devon.odell@gmail.com>
 
 PORTNAME=	go
-PORTVERSION?=	1.17.4
+PORTVERSION?=	1.17.5
 PORTREVISION?=	0
 PORTEPOCH?=	1
 CATEGORIES=	lang

--- a/lang/go/distinfo
+++ b/lang/go/distinfo
@@ -1,6 +1,6 @@
-TIMESTAMP = 1638491034
-SHA256 (go1.17.4.src.tar.gz) = 4bef3699381ef09e075628504187416565d710660fec65b057edf1ceb187fc4b
-SIZE (go1.17.4.src.tar.gz) = 22186114
+TIMESTAMP = 1639102816
+SHA256 (go1.17.5.src.tar.gz) = 3defb9a09bed042403195e872dcbc8c6fae1485963332279668ec52e80a95a2d
+SIZE (go1.17.5.src.tar.gz) = 22186577
 SHA256 (go-freebsd-arm64-go1.14.tar.xz) = f8b0cf0d323e581c9e3e0d5c217847a3e0294fcc92dbac92a5b02cea9d97ad8d
 SIZE (go-freebsd-arm64-go1.14.tar.xz) = 34944548
 SHA256 (go-freebsd-amd64-go1.14.tar.xz) = 3b259247fb228258a4f31e283e9aa23cafd590eabce334666a9e9b2ffe47c19b


### PR DESCRIPTION
Changes:	https://golang.org/doc/devel/release#go1.17.minor
Security:	720505fe-593f-11ec-9ba8-002324b2fba8