### PR TITLE
lang/go-devel: Update to 1.18beta1

### DIFF
--- a/lang/go-devel/Makefile
+++ b/lang/go-devel/Makefile
@@ -1,6 +1,6 @@
 # Created by: Devon H. O'Dell <devon.odell@gmail.com>
 
-PORTVERSION=	g20211209
+PORTVERSION=	g20211214
 # Always set PORTREVISION and PORTEPOCH explicitly as otherwise they are inherited from lang/go
 PORTREVISION=	0
 PORTEPOCH=	0
@@ -16,7 +16,7 @@ COMMENT=	Go programming language (development version)
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	golang
-GH_TAGNAME=	de690c2ff8e323c7ce9e274f986dc6f824b35405
+GH_TAGNAME=	becaeea1199b875bc24800fa88f2f4fea119bf78
 
 CONFLICTS_INSTALL=	go
 

--- a/lang/go-devel/distinfo
+++ b/lang/go-devel/distinfo
@@ -1,8 +1,8 @@
-TIMESTAMP = 1639103175
+TIMESTAMP = 1639528037
 SHA256 (go-freebsd-arm64-go1.14.tar.xz) = f8b0cf0d323e581c9e3e0d5c217847a3e0294fcc92dbac92a5b02cea9d97ad8d
 SIZE (go-freebsd-arm64-go1.14.tar.xz) = 34944548
-SHA256 (golang-go-g20211209-de690c2ff8e323c7ce9e274f986dc6f824b35405_GH0.tar.gz) = 551f28e5dbc0f0563443d8177e5744962dd5e69d9484e3a01a2ca26d7cd10f67
-SIZE (golang-go-g20211209-de690c2ff8e323c7ce9e274f986dc6f824b35405_GH0.tar.gz) = 22159482
+SHA256 (golang-go-g20211214-becaeea1199b875bc24800fa88f2f4fea119bf78_GH0.tar.gz) = 2338765fd1169da79d2325e48538cd22625797d027f5b29d1777fa4a0890338d
+SIZE (golang-go-g20211214-becaeea1199b875bc24800fa88f2f4fea119bf78_GH0.tar.gz) = 22723290
 SHA256 (go-freebsd-amd64-go1.14.tar.xz) = 3b259247fb228258a4f31e283e9aa23cafd590eabce334666a9e9b2ffe47c19b
 SIZE (go-freebsd-amd64-go1.14.tar.xz) = 35927980
 SHA256 (go-freebsd-arm6-go1.14.tar.xz) = 5846b4bbc6881c6c04daffbdb647d53a5b002a0e177271ecfcabef734b209614


### PR DESCRIPTION
Changes:	https://tip.golang.org/doc/go1.18