### PR TITLE
devel/yasm-devel: Mark DEPRECATED and set EXPIRATION_DATE

### DIFF
--- a/devel/yasm-devel/Makefile
+++ b/devel/yasm-devel/Makefile
@@ -14,6 +14,9 @@ COMMENT=	Complete rewrite of the NASM assembler (Development Snapshot)
 LICENSE=	ART10 BSD2CLAUSE BSD3CLAUSE
 LICENSE_COMB=	multi
 
+DEPRECATED=	No need to keep the -devel version due to upstream inactivity
+EXPIRATION_DATE=	2021-12-31
+
 OPTIONS_DEFINE=	DEBUG NLS
 
 GNU_CONFIGURE=		yes


### PR DESCRIPTION
The latest version of yasm was released on August 10, 2014. There is no
need to keep the -devel port, and it is even more confusing since it is
currently older than the non-devel port.

PR:		260185
Approved by:	koobs (maintainer timeout, > 3 weeks)