### PR TITLE
dns/dnsdist: Update to 1.7.0

### DIFF
--- a/dns/dnsdist/Makefile
+++ b/dns/dnsdist/Makefile
@@ -1,7 +1,7 @@
 # Created by: Carlos J Puga Medina <cpm@fbsd.es>
 
 PORTNAME=	dnsdist
-DISTVERSION=	1.6.1
+DISTVERSION=	1.7.0
 CATEGORIES=	dns net
 MASTER_SITES=	https://downloads.powerdns.com/releases/
 

--- a/dns/dnsdist/distinfo
+++ b/dns/dnsdist/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1631700092
-SHA256 (dnsdist-1.6.1.tar.bz2) = 29040a43982ae1ad5b7313f081e26519ab3a58af6bced438311da3a65370a3a5
-SIZE (dnsdist-1.6.1.tar.bz2) = 1328069
+TIMESTAMP = 1642434869
+SHA256 (dnsdist-1.7.0.tar.bz2) = 78cc72cb0ccf7fb5f3f2fae09c79eda65a5256374da09bb541b735ea6868fc64
+SIZE (dnsdist-1.7.0.tar.bz2) = 1392585


### PR DESCRIPTION
Changelog:	https://blog.powerdns.com/2022/01/17/dnsdist-1-7-0-released/

PR:		261421