### PR TITLE
databases/mongodb50: Update to 5.0.6

### DIFF
--- a/databases/mongodb50/Makefile
+++ b/databases/mongodb50/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	mongodb
 DISTVERSIONPREFIX=	r
-DISTVERSION=	5.0.5
+DISTVERSION=	5.0.6
 CATEGORIES=	databases net
 MASTER_SITES=	https://fastdl.mongodb.org/src/ \
 		http://fastdl.mongodb.org/src/
@@ -41,7 +41,7 @@ GROUPS=		mongodb
 OPTIONS_DEFINE=			LTO SASL SSL
 OPTIONS_DEFAULT=		LTO SASL SSL
 OPTIONS_EXCLUDE_aarch64=	${OPTIONS_EXCLUDE_${ARCH}_${OSREL:R}}
-OPTIONS_EXCLUDE_aarch64_14=	LTO # Does not work with llvm12 on aarch64.
+OPTIONS_EXCLUDE_aarch64_14=	LTO # Does not work with llvm12/llvm13 on aarch64.
 
 MAKE_ARGS=	--cxx-std=17 \
 		--disable-warnings-as-errors \
@@ -70,7 +70,9 @@ EXTRA_PATCHES=	${FILESDIR}/${ARCH}
 
 ALL_TARGET=	install-core
 
-PORTSCOUT=	limitw:1,even
+# This ports is only following the Major Release.
+# https://docs.mongodb.com/manual/reference/versioning/
+PORTSCOUT=	limit:^5\.0\.
 
 CPE_PRODUCT=	mongodb
 

--- a/databases/mongodb50/distinfo
+++ b/databases/mongodb50/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1638470985
-SHA256 (mongodb-src-r5.0.5.tar.gz) = 462090203869f393696e44e4b17a8114b9fdce7c137dcd59fa685ec3873adeda
-SIZE (mongodb-src-r5.0.5.tar.gz) = 54862473
+TIMESTAMP = 1643321310
+SHA256 (mongodb-src-r5.0.6.tar.gz) = 9d514eef9093d383120aebe4469c8118a39f390afcd8cd9af2399076b27abb52
+SIZE (mongodb-src-r5.0.6.tar.gz) = 56000348


### PR DESCRIPTION
- Fix PORTSCOUT; mongo changed versioning policy
- Document llvm13 as not working with LTO on aarch64 either

Changelog:	https://docs.mongodb.com/manual/release-notes/5.0-changelog/#5.0.6-changelog

PR:		261533