### PR TITLE
x11-fm/doublecmd: Update to 1.0.4

### DIFF
--- a/x11-fm/doublecmd/Makefile
+++ b/x11-fm/doublecmd/Makefile
@@ -1,9 +1,8 @@
 # Created by: Beñat Gonzalez Etxepare <bbtruk@users.sourceforge.net>
 
 PORTNAME=	doublecmd
-PORTVERSION=	1.0.2
+PORTVERSION=	1.0.4
 DISTVERSIONPREFIX=	v
-PORTREVISION=	1
 CATEGORIES=	x11-fm
 PKGNAMESUFFIX=	${LAZARUS_PKGNAMESUFFIX}
 

--- a/x11-fm/doublecmd/distinfo
+++ b/x11-fm/doublecmd/distinfo
@@ -1,5 +1,5 @@
-TIMESTAMP = 1639375830
-SHA256 (doublecmd-doublecmd-v1.0.2_GH0.tar.gz) = 0cad26eac4d2d75383f829cf6b8095da6f1913620342575491c4029d98cdd597
-SIZE (doublecmd-doublecmd-v1.0.2_GH0.tar.gz) = 9033241
+TIMESTAMP = 1644820349
+SHA256 (doublecmd-doublecmd-v1.0.4_GH0.tar.gz) = afa1b9589d8da819b817700e78cb04b02f60fd942a3e969e8b5a6b966bba5be9
+SIZE (doublecmd-doublecmd-v1.0.4_GH0.tar.gz) = 9037039
 SHA256 (doublecmd-doublecmd.github.io-1.0.0_GH0.tar.gz) = b078a6e9ecad3d661827b96bce10115430b0082ad4c972b2abbf4faeee084010
 SIZE (doublecmd-doublecmd.github.io-1.0.0_GH0.tar.gz) = 7031082


### PR DESCRIPTION
Changelog:	https://github.com/doublecmd/doublecmd/releases/tag/v1.0.4

PR:		261951
MFH:		2022Q1 (bugfix release)