### PR TITLE
devel/rubygem-oci: Update to 2.17.0

### DIFF
--- a/devel/rubygem-oci/Makefile
+++ b/devel/rubygem-oci/Makefile
@@ -1,7 +1,7 @@
 # Created by: Alessandro Sagratini <ale_sagra@hotmail.com>
 
 PORTNAME=	oci
-DISTVERSION=	2.16.0
+DISTVERSION=	2.17.0
 CATEGORIES=	devel rubygems
 MASTER_SITES=	RG
 

--- a/devel/rubygem-oci/distinfo
+++ b/devel/rubygem-oci/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1643791760
-SHA256 (rubygem/oci-2.16.0.gem) = 5c16265a3c4d7b1dcd63132411f159f7ea853a7b3a97f9ab7813bc5b1c686f12
-SIZE (rubygem/oci-2.16.0.gem) = 5009920
+TIMESTAMP = 1644994744
+SHA256 (rubygem/oci-2.17.0.gem) = 90096fa54732e16247c4fc34ffa5155c70c7106cf252cfaf45d2e6bd5d81ab5c
+SIZE (rubygem/oci-2.17.0.gem) = 5337600


### PR DESCRIPTION
Changelog:	https://github.com/oracle/oci-ruby-sdk/releases/tag/v2.17.0

PR:		261983