### PR TITLE
lang/go: Update to 1.17.7

### DIFF
--- a/lang/go/Makefile
+++ b/lang/go/Makefile
@@ -1,7 +1,7 @@
 # Created by: Devon H. O'Dell <devon.odell@gmail.com>
 
 PORTNAME=	go
-PORTVERSION?=	1.17.6
+PORTVERSION?=	1.17.7
 PORTREVISION?=	0
 PORTEPOCH?=	1
 CATEGORIES=	lang

--- a/lang/go/distinfo
+++ b/lang/go/distinfo
@@ -1,6 +1,6 @@
-TIMESTAMP = 1641503777
-SHA256 (go1.17.6.src.tar.gz) = 4dc1bbf3ff61f0c1ff2b19355e6d88151a70126268a47c761477686ef94748c8
-SIZE (go1.17.6.src.tar.gz) = 22191372
+TIMESTAMP = 1645166300
+SHA256 (go1.17.7.src.tar.gz) = c108cd33b73b1911a02b697741df3dea43e01a5c4e08e409e8b3a0e3745d2b4d
+SIZE (go1.17.7.src.tar.gz) = 22195583
 SHA256 (go-freebsd-arm64-go1.14.tar.xz) = f8b0cf0d323e581c9e3e0d5c217847a3e0294fcc92dbac92a5b02cea9d97ad8d
 SIZE (go-freebsd-arm64-go1.14.tar.xz) = 34944548
 SHA256 (go-freebsd-amd64-go1.14.tar.xz) = 3b259247fb228258a4f31e283e9aa23cafd590eabce334666a9e9b2ffe47c19b


### PR DESCRIPTION
Changes:	https://golang.org/doc/devel/release#go1.17.minor
Security:	096ab080-907c-11ec-bb14-002324b2fba8