### PR TITLE
security/tpm2-tools: Remove redundant BROKEN_SSL

### DIFF
--- a/security/tpm2-tools/Makefile
+++ b/security/tpm2-tools/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	tpm2-tools
 DISTVERSION=	5.2
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	https://github.com/tpm2-software/tpm2-tools/releases/download/${DISTVERSION}/
 
@@ -17,7 +18,5 @@ USES=		compiler:c11 gmake libtool pkgconfig ssl
 GNU_CONFIGURE=	yes
 CONFIGURE_ENV=	CRYPTO_CFLAGS="-I${OPENSSLINC}" CRYPTO_LIBS="-L${OPENSSLLIB} -lcrypto"
 CONFIGURE_ARGS=	--disable-hardening --disable-fapi
-
-BROKEN_SSL=	openssl
 
 .include <bsd.port.mk>


### PR DESCRIPTION
Differential Revision:	https://reviews.freebsd.org/D34608