### PR TITLE
mail/mutt: Update to 2.2.2

### DIFF
--- a/mail/mutt/Makefile
+++ b/mail/mutt/Makefile
@@ -1,7 +1,7 @@
 # Created by: Udo Schweigert
 
 PORTNAME=	mutt
-DISTVERSION=	2.2.1
+DISTVERSION=	2.2.2
 CATEGORIES+=	mail
 MASTER_SITES=	ftp://ftp.mutt.org/pub/mutt/ \
 		https://bitbucket.org/mutt/mutt/downloads/ \
@@ -10,9 +10,9 @@ MASTER_SITES=	ftp://ftp.mutt.org/pub/mutt/ \
 DIST_SUBDIR=	mutt
 EXTRACT_ONLY=	${DISTNAME}${EXTRACT_SUFX}
 
-PATCH_SITES+=		http://www.mutt.org.ua/download/mutt-${VVV_PATCH_VERSION}/:vvv \
-			http://www2.mutt.org.ua/download/mutt-${VVV_PATCH_VERSION}/:vvv \
-			http://vc.org.ua/mutt/:vc
+PATCH_SITES+=	http://www.mutt.org.ua/download/mutt-${VVV_PATCH_VERSION}/:vvv \
+		http://www2.mutt.org.ua/download/mutt-${VVV_PATCH_VERSION}/:vvv \
+		http://vc.org.ua/mutt/:vc
 PATCH_DIST_STRIP=	-p1
 
 MAINTAINER=	dereks@lifeofadishwasher.com
@@ -42,23 +42,26 @@ CONFIGURE_ARGS=	--disable-fcntl \
 CONFIGURE_ARGS+=	${MUTT_CONFIGURE_ARGS}
 .endif
 
-CONFLICTS=	ja-mutt ja-mutt-devel mutt-1.4* \
-		mutt-devel-lite mutt-lite zh-mutt-devel
+CONFLICTS=	ja-mutt ja-mutt-devel mutt-1.4* mutt-devel-lite mutt-lite \
+		zh-mutt-devel
 
 INFO=		${PORTNAME}
 
-OPTIONS_SUB=	yes
-
-OPTIONS_DEFINE=	AUTOCRYPT DEBUG_LOGS DOCS EXAMPLES FLOCK GPGME GREETING_PATCH \
-		HTML ICONV IDN IFDEF_PATCH LOCALES_FIX MAILBOX_MANPAGES \
-		MAILDIR_MTIME_PATCH NLS QUOTE_PATCH REVERSE_REPLY_PATCH SASL \
-		SMART_DATE SMIME SMTP URLVIEW
+OPTIONS_DEFINE=		AUTOCRYPT DEBUG_LOGS DOCS EXAMPLES FLOCK GPGME \
+			GREETING_PATCH HTML ICONV IDN IFDEF_PATCH LOCALES_FIX \
+			MAILBOX_MANPAGES MAILDIR_MTIME_PATCH NLS QUOTE_PATCH \
+			REVERSE_REPLY_PATCH SASL SMART_DATE SMIME SMTP URLVIEW
+OPTIONS_DEFAULT=	AUTOCRYPT DEBUG_LOGS GPGME GSSAPI_NONE HCACHE_BDB HTML \
+			ICONV IDN IFDEF_PATCH LOCALES_FIX MAILBOX_MANPAGES \
+			MAILDIR_MTIME_PATCH NCURSES NLS QUOTE_PATCH \
+			REVERSE_REPLY_PATCH SASL SMART_DATE SMIME SMTP URLVIEW
 
 OPTIONS_SINGLE=		GSSAPI HCACHE SCREEN
 OPTIONS_SINGLE_GSSAPI=	GSSAPI_BASE GSSAPI_HEIMDAL GSSAPI_MIT GSSAPI_NONE
 OPTIONS_SINGLE_HCACHE=	HCACHE_BDB HCACHE_KYOTOCABINET HCACHE_NONE \
 			HCACHE_TOKYOCABINET
 OPTIONS_SINGLE_SCREEN=	NCURSES SLANG
+OPTIONS_SUB=		yes
 
 AUTOCRYPT_DESC=			Convenient End-to-End Encryption
 DEBUG_LOGS_DESC=		Debugging capabilities
@@ -81,48 +84,35 @@ NLS_DESC=			Native language support (implies ICONV)
 QUOTE_PATCH_DESC=		Extended quoting
 REVERSE_REPLY_PATCH_DESC=	Reverse_reply
 SASL_DESC=			SASL authentication
-SMIME_DESC=			SMIME email check option patch
 SLANG_DESC=			SLANG support
 SMART_DATE_DESC=		Dynamic date formatting with "%@"
+SMIME_DESC=			SMIME email check option patch
 SMTP_DESC=			SMTP relay support
 URLVIEW_DESC=			Use urlview for the URL selector menu
 
-OPTIONS_DEFAULT=	AUTOCRYPT DEBUG_LOGS GPGME GSSAPI_NONE HCACHE_BDB HTML \
-			ICONV IDN IFDEF_PATCH LOCALES_FIX MAILBOX_MANPAGES \
-			MAILDIR_MTIME_PATCH NCURSES NLS QUOTE_PATCH \
-			REVERSE_REPLY_PATCH SASL SMART_DATE SMIME SMTP URLVIEW
-
-.ifmake makesum # for optional distfiles patchfiles
-OPTIONS_OVERRIDE=	${OPTIONS_DEFAULT} ${OPTIONS_DEFINE}
-.MAKEOVERRIDES+=	OPTIONS_OVERRIDE
-.endif
-
-AUTOCRYPT_CONFIGURE_ENABLE=	autocrypt
 AUTOCRYPT_IMPLIES=		GPGME IDN
+AUTOCRYPT_BUILD_DEPENDS=	${AUTOCRYPT_DEPENDS}
+AUTOCRYPT_RUN_DEPENDS=		${AUTOCRYPT_DEPENDS}
 AUTOCRYPT_USES=			sqlite:3
+AUTOCRYPT_CONFIGURE_ENABLE=	autocrypt
 AUTOCRYPT_CONFIGURE_WITH=	sqlite3=${LOCALBASE}
 AUTOCRYPT_DEPENDS=		gnupg>=2.1:security/gnupg \
 				gpgme>=1.8:security/gpgme
-AUTOCRYPT_BUILD_DEPENDS=	${AUTOCRYPT_DEPENDS}
-AUTOCRYPT_RUN_DEPENDS=		${AUTOCRYPT_DEPENDS}
-
-URLVIEW_RUN_DEPENDS=	urlview:textproc/urlview
 
 DEBUG_LOGS_CONFIGURE_ON=	--enable-debug
 
-DOCS_CONFIGURE_OFF=	--disable-doc
 DOCS_BUILD_DEPENDS=	lynx:www/lynx
+DOCS_CONFIGURE_OFF=	--disable-doc
 
-# Handle ncurses/ncurses-port/slang
-SLANG_CONFIGURE_ON=	--with-slang=${LOCALBASE}
-SLANG_LIB_DEPENDS=	libslang.so:devel/libslang2
-SLANG_VARS=		PKGMESSAGE=${FILESDIR}/pkg-message.slang
+FLOCK_CONFIGURE_ENABLE=	flock
 
-NCURSES_USES=	ncurses
+GPGME_LIB_DEPENDS+=	libassuan.so:security/libassuan \
+			libgpg-error.so:security/libgpg-error \
+			libgpgme.so:security/gpgme
 
-NLS_USES=		gettext
-NLS_CONFIGURE_ENABLE=	nls
-NLS_IMPLIES=		ICONV
+GPGME_CONFIGURE_ENABLE=	gpgme
+
+GREETING_PATCH_PATCHFILES=	mutt-${GREETING_PATCH_VERSION}.vc.greeting:vc
 
 # Handle GSSAPI from various places
 GSSAPI_BASE_USES=		gssapi
@@ -136,57 +126,65 @@ GSSAPI_MIT_CONFIGURE_ON=	${GSSAPI_CONFIGURE_ARGS} \
 				--with-gss=${GSSAPIBASEDIR}
 GSSAPI_NONE_CONFIGURE_ON=	--without-gss
 
-HCACHE_NONE_CONFIGURE_ON=	--disable-hcache
-HCACHE_NONE_CONFIGURE_OFF=	--enable-hcache
-
-HCACHE_BDB_CONFIGURE_WITH=	bdb=${LOCALBASE}
-HCACHE_BDB_USES=		bdb:42+
-HCACHE_BDB_VARS=		CFLAGS+=-I${BDB_INCLUDE_DIR} \
-				LDFLAGS+=-L${BDB_LIB_DIR}
-
-HCACHE_TOKYOCABINET_CONFIGURE_WITH=	tokyocabinet=${LOCALBASE}
-HCACHE_TOKYOCABINET_LIB_DEPENDS=	libtokyocabinet.so:databases/tokyocabinet
-
-HCACHE_KYOTOCABINET_CONFIGURE_WITH=	kyotocabinet=${LOCALBASE}
+HCACHE_BDB_USES=			bdb:42+
+HCACHE_BDB_CONFIGURE_WITH=		bdb=${LOCALBASE}
+HCACHE_BDB_VARS=			CFLAGS+=-I${BDB_INCLUDE_DIR} \
+					LDFLAGS+=-L${BDB_LIB_DIR}
 HCACHE_KYOTOCABINET_LIB_DEPENDS=	libkyotocabinet.so:databases/kyotocabinet
+HCACHE_KYOTOCABINET_CONFIGURE_WITH=	kyotocabinet=${LOCALBASE}
+HCACHE_NONE_CONFIGURE_ON=		--disable-hcache
+HCACHE_NONE_CONFIGURE_OFF=		--enable-hcache
+HCACHE_TOKYOCABINET_LIB_DEPENDS=	libtokyocabinet.so:databases/tokyocabinet
+HCACHE_TOKYOCABINET_CONFIGURE_WITH=	tokyocabinet=${LOCALBASE}
 
 ICONV_USES=		iconv:translit
 ICONV_CONFIGURE_ON=	${ICONV_CONFIGURE_ARG}
 ICONV_CONFIGURE_OFF=	--disable-iconv
+
+IDN_IMPLIES=		ICONV
+IDN_LIB_DEPENDS=	libidn2.so:dns/libidn2 \
+			libunistring.so:devel/libunistring
+IDN_CONFIGURE_WITH=	idn2=${LOCALBASE}
+
+IFDEF_PATCH_EXTRA_PATCHES=	${PATCHDIR}/extra-patch-ifdef
+
+LOCALES_FIX_CONFIGURE_ON=	--enable-locales-fix
+
+MAILDIR_MTIME_PATCH_EXTRA_PATCHES=	${PATCHDIR}/extra-patch-maildir-mtime
+
+NCURSES_USES=	ncurses
+
+NLS_IMPLIES=		ICONV
+NLS_USES=		gettext
+NLS_CONFIGURE_ENABLE=	nls
+
+QUOTE_PATCH_PATCHFILES=	patch-${VVV_PATCH_VERSION}.vvv.initials.xz:vvv \
+			mutt-${GREETING_PATCH_VERSION}.vvv.quote:vc
 
 REVERSE_REPLY_PATCH_EXTRA_PATCHES=	${PATCHDIR}/extra-patch-reverse_reply
 
 SASL_LIB_DEPENDS=	libsasl2.so:security/cyrus-sasl2
 SASL_CONFIGURE_ON=	--with-sasl=${LOCALBASE}
 
-SMIME_EXTRA_PATCHES=	${PATCHDIR}/extra-smime-sender
+# Handle ncurses/ncurses-port/slang
+SLANG_LIB_DEPENDS=	libslang.so:devel/libslang2
+SLANG_CONFIGURE_ON=	--with-slang=${LOCALBASE}
+SLANG_VARS=		PKGMESSAGE=${FILESDIR}/pkg-message.slang
 
 SMART_DATE_EXTRA_PATCHES=	${PATCHDIR}/extra-patch-smartdate
 
-FLOCK_CONFIGURE_ENABLE=	flock
-
-LOCALES_FIX_CONFIGURE_ON=	--enable-locales-fix
-
-IDN_LIB_DEPENDS=	libidn2.so:dns/libidn2 \
-			libunistring.so:devel/libunistring
-IDN_CONFIGURE_WITH=	idn2=${LOCALBASE}
-IDN_IMPLIES=		ICONV
-
-IFDEF_PATCH_EXTRA_PATCHES=	${PATCHDIR}/extra-patch-ifdef
-
-GPGME_LIB_DEPENDS+=	libassuan.so:security/libassuan \
-			libgpg-error.so:security/libgpg-error \
-			libgpgme.so:security/gpgme
-GPGME_CONFIGURE_ENABLE=	gpgme
+SMIME_EXTRA_PATCHES=	${PATCHDIR}/extra-smime-sender
 
 SMTP_CONFIGURE_ENABLE=	smtp
 
-MAILDIR_MTIME_PATCH_EXTRA_PATCHES=	${PATCHDIR}/extra-patch-maildir-mtime
+URLVIEW_RUN_DEPENDS=	urlview:textproc/urlview
 
-GREETING_PATCH_PATCHFILES=	mutt-${GREETING_PATCH_VERSION}.vc.greeting:vc
-
-QUOTE_PATCH_PATCHFILES=	patch-${VVV_PATCH_VERSION}.vvv.initials.xz:vvv \
-			mutt-${GREETING_PATCH_VERSION}.vvv.quote:vc
+.ifnmake portclippy
+.ifmake makesum # for optional distfiles patchfiles
+OPTIONS_OVERRIDE=	${OPTIONS_DEFAULT} ${OPTIONS_DEFINE}
+.MAKEOVERRIDES+=	OPTIONS_OVERRIDE
+.endif
+.endif
 
 .include <bsd.port.options.mk>
 

--- a/mail/mutt/distinfo
+++ b/mail/mutt/distinfo
@@ -1,6 +1,6 @@
-TIMESTAMP = 1645313041
-SHA256 (mutt/mutt-2.2.1.tar.gz) = b76d30d42b6c90aa9abf9f330e41800934eedf7b858a32c120ee3ae63587abb5
-SIZE (mutt/mutt-2.2.1.tar.gz) = 5503979
+TIMESTAMP = 1648312918
+SHA256 (mutt/mutt-2.2.2.tar.gz) = 10de870cf37646c0b3f5bcf579c3cc2fd9285bda1d04be9ad7c33ec2ee820fcc
+SIZE (mutt/mutt-2.2.2.tar.gz) = 5507066
 SHA256 (mutt/mutt-2.2.0.vc.greeting) = 7abb467cfaa0ccbfa1fa7cdf8585eefef94e039459ff95fb59efe23043d941d2
 SIZE (mutt/mutt-2.2.0.vc.greeting) = 1979
 SHA256 (mutt/patch-1.13.0.vvv.initials.xz) = 8b25ad6596bd57d94f6551e7e73ceb8da620468e96fb507b2f51545d5b3eaa02


### PR DESCRIPTION
- Portclippy/portfmt cleanup
- Tell portclippy to ignore makesum hack

Changelog:	https://marc.info/?l=mutt-users&m=164824319527784&w=2

PR:		262849