### PR TITLE
security/tpm2-abrmd: Improve rc.d script and add devd config

### DIFF
--- a/security/tpm2-abrmd/Makefile
+++ b/security/tpm2-abrmd/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	tpm2-abrmd
 DISTVERSION=	2.4.1
+PORTREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	https://github.com/tpm2-software/tpm2-abrmd/releases/download/${DISTVERSION}/
 
@@ -24,6 +25,9 @@ GROUPS=		_tss
 USERS=		_tss
 
 SUB_LIST=	DBUS_DAEMON=dbus
+
+pre-install:
+	@${INSTALL_DATA} ${FILESDIR}/tpm2-abrmd-devd.conf ${STAGEDIR}${PREFIX}/etc/devd
 
 post-install:
 	@${RM} ${STAGEDIR}${PREFIX}/lib/systemd/system-preset/tpm2-abrmd.preset

--- a/security/tpm2-abrmd/files/tpm2-abrmd-devd.conf
+++ b/security/tpm2-abrmd/files/tpm2-abrmd-devd.conf
@@ -1,0 +1,6 @@
+# Allow members of _tss group to access tpm device
+
+notify 100 {
+	device-name	"tpm0";
+	action		"chgrp _tss /dev/$cdev; chmod g+rw /dev/$cdev";
+};

--- a/security/tpm2-abrmd/files/tpm2-abrmd.in
+++ b/security/tpm2-abrmd/files/tpm2-abrmd.in
@@ -12,13 +12,61 @@
 . /etc/rc.subr
 
 name=tpm2_abrmd
-desc=TPM2 Access Broker & Resource Management Daemon
+desc="TPM2 Access Broker & Resource Management Daemon"
 rcvar=tpm2_abrmd_enable
 load_rc_config ${name}
 
 : ${tpm2_abrmd_enable:=NO}
 
 command=%%PREFIX%%/sbin/tpm2-abrmd
-tpm2_abrmd_user=_tss
+tpm2_abrmd_user="_tss"
+tpm2_abrmd_group="_tss"
+pidfile="/var/run/${name}.pid"
+logfile="/var/log/${name}.log"
+start_cmd="tpm2_abrmd_start"
+stop_cmd="tpm2_abrmd_stop"
+status_cmd="tpm2_abrmd_status"
+
+is_process_running() {
+    [ -f ${pidfile} ] && procstat `cat ${pidfile}` >/dev/null 2>&1
+}
+
+tpm2_abrmd_start()
+{
+    if is_process_running; then
+        echo "${name} already running as pid $(cat $pidfile)"
+        return 1
+    fi
+
+    touch $logfile
+    chmod 640 $logfile
+    chown -R ${tpm2_abrmd_user}:${tpm2_abrmd_group} ${logfile}
+    /usr/sbin/daemon -P ${pidfile} -u ${tpm2_abrmd_user} ${command} >>${logfile} 2>&1
+
+    if is_process_running; then
+        echo "Started ${name}, pid $(cat ${pidfile})"
+    else
+        echo "Failed to start ${name}"
+    fi
+}
+
+tpm2_abrmd_stop()
+{
+    if is_process_running; then
+        echo "Stopping ${name}"
+        kill -- -$(cat ${pidfile})
+        /bin/rm -f ${pidfile}
+    else
+        echo "${name} isn't running"
+    fi
+}
+
+tpm2_abrmd_status() {
+    if is_process_running; then
+        echo "${name} is running as pid $(cat ${pidfile})"
+    else
+        echo "${name} isn't running"
+    fi
+}
 
 run_rc_command "$1"

--- a/security/tpm2-abrmd/pkg-plist
+++ b/security/tpm2-abrmd/pkg-plist
@@ -1,5 +1,6 @@
 include/tss2/tss2-tcti-tabrmd.h
 etc/dbus-1/system.d/tpm2-abrmd.conf
+etc/devd/tpm2-abrmd-devd.conf
 lib/libtss2-tcti-tabrmd.a
 lib/libtss2-tcti-tabrmd.so
 lib/libtss2-tcti-tabrmd.so.0


### PR DESCRIPTION
- Improve tpm2-abrmd rc.d script
- Add devd config file, which adds rules for /dev/tpm0 char device. It allows the _tss group members to read and write the tpm device, which is required by tpm2-abrmd to communicate with the device.

Differential Revision:	https://reviews.freebsd.org/D34744