### PR TITLE
lang/go117: Add go 1.17 back

### DIFF
--- a/lang/Makefile
+++ b/lang/Makefile
@@ -113,6 +113,7 @@
     SUBDIR += gnustep-base
     SUBDIR += go
     SUBDIR += go-devel
+    SUBDIR += go117
     SUBDIR += gomacro
     SUBDIR += gprolog
     SUBDIR += gravity

--- a/lang/go117/Makefile
+++ b/lang/go117/Makefile
@@ -1,0 +1,28 @@
+PORTVERSION=	1.17.8
+# Always set PORTREVISION and PORTEPOCH explicitly as otherwise they are inherited from lang/go
+PORTREVISION=	0
+PORTEPOCH=	0
+MASTER_SITES=	https://github.com/dmgk/go-bootstrap/releases/download/${BOOTSTRAP_TAG}/:bootstrap \
+		LOCAL/dmgk:bootstrap
+PKGNAMESUFFIX=	-devel
+DISTFILES=	go-${OPSYS:tl}-${GOARCH_${ARCH}}${GOARM_${ARCH}}-${BOOTSTRAP_TAG}.tar.xz:bootstrap
+
+# Avoid conflicting patch files
+PATCHFILES=
+
+COMMENT=	Go programming language (development version)
+
+USE_GITHUB=	yes
+GH_ACCOUNT=	golang
+GH_TAGNAME=	7dd10d4ce20e64d96a10cb67794851a58d96a2aa
+
+CONFLICTS_INSTALL=	go
+
+MASTERDIR=	${.CURDIR}/../go
+PATCHDIR=	${.CURDIR}/files
+DISTINFO_FILE=	${.CURDIR}/distinfo
+
+post-extract:
+	@[ -f ${WRKSRC}/VERSION ] || ${ECHO_CMD} "${PORTVERSION} +${GH_TAGNAME}" > ${WRKSRC}/VERSION
+
+.include "${MASTERDIR}/Makefile"

--- a/lang/go117/distinfo
+++ b/lang/go117/distinfo
@@ -1,0 +1,13 @@
+TIMESTAMP = 1649116438
+SHA256 (go-freebsd-arm64-go1.14.tar.xz) = d1db1a73575b361815b7fafdc33b095337f7f3795ba9960ae712f6f4754a9ca6
+SIZE (go-freebsd-arm64-go1.14.tar.xz) = 17956864
+SHA256 (golang-go-1.17.8-7dd10d4ce20e64d96a10cb67794851a58d96a2aa_GH0.tar.gz) = 903cb4363af9a1c9a6c9d08ea0525983634862a5cb1f893b0b6156e3b99f847c
+SIZE (golang-go-1.17.8-7dd10d4ce20e64d96a10cb67794851a58d96a2aa_GH0.tar.gz) = 22176903
+SHA256 (go-freebsd-amd64-go1.14.tar.xz) = 3b259247fb228258a4f31e283e9aa23cafd590eabce334666a9e9b2ffe47c19b
+SIZE (go-freebsd-amd64-go1.14.tar.xz) = 35927980
+SHA256 (go-freebsd-arm6-go1.14.tar.xz) = 5846b4bbc6881c6c04daffbdb647d53a5b002a0e177271ecfcabef734b209614
+SIZE (go-freebsd-arm6-go1.14.tar.xz) = 35164388
+SHA256 (go-freebsd-arm7-go1.14.tar.xz) = 3d40c0f093bc3dc6cb84e92f8462a9c6a88a19a0ba75f813211f9d5d766b7737
+SIZE (go-freebsd-arm7-go1.14.tar.xz) = 35398032
+SHA256 (go-freebsd-386-go1.14.tar.xz) = c1a798154ae1ed2be6027d883e4611dd19edbe07a3f6d4f71d9437bddf3ed9ca
+SIZE (go-freebsd-386-go1.14.tar.xz) = 36118928

--- a/lang/go117/files/patch-src_cmd_go_internal_modload_vendor.go
+++ b/lang/go117/files/patch-src_cmd_go_internal_modload_vendor.go
@@ -1,0 +1,11 @@
+--- src/cmd/go/internal/modload/vendor.go.orig	2020-12-17 16:03:19 UTC
++++ src/cmd/go/internal/modload/vendor.go
+@@ -133,7 +133,7 @@ func checkVendorConsistency() {
+ 	readVendorList()
+ 
+ 	pre114 := false
+-	if semver.Compare(index.goVersionV, "v1.14") < 0 {
++	if semver.Compare(index.goVersionV, "v1.14") < 0 || (os.Getenv("GO_NO_VENDOR_CHECKS") == "1" && len(vendorMeta) == 0) {
+ 		// Go versions before 1.14 did not include enough information in
+ 		// vendor/modules.txt to check for consistency.
+ 		// If we know that we're on an earlier version, relax the consistency check.


### PR DESCRIPTION
Some ports have dependencies that are not compatible with go 1.18 yet.
Add 1.17 back to allow these ports to build.