### PR TITLE
sysutils/ipfs-go: Fix build

### DIFF
--- a/sysutils/ipfs-go/Makefile
+++ b/sysutils/ipfs-go/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=	ipfs
 DISTVERSIONPREFIX=	v
 DISTVERSION=	0.11.0
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	sysutils
 MASTER_SITES=	https://github.com/ipfs/go-ipfs/releases/download/v${DISTVERSION}/
 PKGNAMESUFFIX=	-go
@@ -20,6 +20,7 @@ USES=		cpe go:modules
 CPE_VENDOR=	protocol
 
 GO_TARGET=	./cmd/ipfs:ipfs-go
+GO_PORT=	lang/go117 # quic-go does not build on Go 1.18 yet
 
 NO_WRKSUBDIR=	yes
 


### PR DESCRIPTION
ipfs-go has a dependency which does not support go 1.18 yet. Use 1.17
for now.

PR:		263050
Reported by:	jmg
Approved by:	portmgr (build fix)