### PR TITLE
www/adguardhome: Fix build

### DIFF
--- a/www/adguardhome/Makefile
+++ b/www/adguardhome/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=	adguardhome
 DISTVERSIONPREFIX=	v
 DISTVERSION=	0.107.0-b.7
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	www
 
 MAINTAINER=	yuri@FreeBSD.org
@@ -13,6 +13,7 @@ LICENSE_FILE=	${WRKSRC}/LICENSE.txt
 USES=		cpe go:modules
 
 GO_MODULE=	github.com/AdguardTeam/AdGuardHome
+GO_PORT=	lang/go117 # quic-go does not build on Go 1.18 yet
 
 # to rebuild the deps archives:
 #   1. set DEV_UPDATE_MODE=yes


### PR DESCRIPTION
adguardhome has a dependency which does not support go 1.18 yet. Use
1.17 for now.

PR:		262994
Reported by:	Yonas Yanfa <yonas.yanfa@gmail.com>
Approved by:	portmgr (implicit, build fix)