### PR TITLE
databases/squirrel-sql: Update to 4.3.0

### DIFF
--- a/databases/squirrel-sql/Makefile
+++ b/databases/squirrel-sql/Makefile
@@ -1,7 +1,7 @@
 # Created by: Roy Boerner
 
 PORTNAME=	squirrel-sql
-PORTVERSION=	4.2.0
+PORTVERSION=	4.3.0
 CATEGORIES=	databases java
 MASTER_SITES=	SF/${PORTNAME}/1-stable/${PORTVERSION}-plainzip
 DISTNAME=	squirrelsql-${PORTVERSION}-optional
@@ -13,7 +13,7 @@ LICENSE=	GPLv2
 
 USES=		zip
 
-USE_JAVA=	8+
+USE_JAVA=	11+
 NO_BUILD=	yes
 NO_ARCH=	yes
 WRKSRC=		${WRKDIR}/${DISTNAME}

--- a/databases/squirrel-sql/distinfo
+++ b/databases/squirrel-sql/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1622511901
-SHA256 (squirrelsql-4.2.0-optional.zip) = 664ee4f2cf40b3a6e12ee57cbfa1361a156ee8539862b04fa85ad39c873f1105
-SIZE (squirrelsql-4.2.0-optional.zip) = 59859070
+TIMESTAMP = 1649462396
+SHA256 (squirrelsql-4.3.0-optional.zip) = 74888b0223949e8efe55fb24d8872df6986ea0c361d6a5fbf4c74cf86d42c13a
+SIZE (squirrelsql-4.3.0-optional.zip) = 59972791

--- a/databases/squirrel-sql/pkg-plist
+++ b/databases/squirrel-sql/pkg-plist
@@ -118,7 +118,6 @@ bin/squirrel-sql
 %%DATADIR%%/lib/jsqlparser-3.3-SNAPSHOT.jar
 %%DATADIR%%/lib/log4j.jar
 %%DATADIR%%/lib/markdowngeneratorJava1_6.jar
-%%DATADIR%%/lib/nanoxml.jar
 %%DATADIR%%/lib/org.eclipse.equinox.common.jar
 %%DATADIR%%/lib/poi-ooxml-schemas.jar
 %%DATADIR%%/lib/poi-ooxml.jar
@@ -286,6 +285,11 @@ bin/squirrel-sql
 %%DATADIR%%/plugins/hibernate/doc/licence.txt
 %%DATADIR%%/plugins/hibernate/doc/readme.html
 %%DATADIR%%/plugins/hibernate/doc/session.png
+%%DATADIR%%/plugins/highresicon.jar
+%%DATADIR%%/plugins/highresicon/doc/changes.txt
+%%DATADIR%%/plugins/highresicon/doc/licence.txt
+%%DATADIR%%/plugins/highresicon/doc/readme.txt
+%%DATADIR%%/plugins/highresicon/lib/xbrz-1.8.jar
 %%DATADIR%%/plugins/i18n.jar
 %%DATADIR%%/plugins/i18n/doc/changes.txt
 %%DATADIR%%/plugins/i18n/doc/licence.txt
@@ -316,7 +320,7 @@ bin/squirrel-sql
 %%DATADIR%%/plugins/laf/doc/tinylaf-license.txt
 %%DATADIR%%/plugins/laf/doc/tonic-licence.txt
 %%DATADIR%%/plugins/laf/lafs/JTattoo-1.6.10.jar
-%%DATADIR%%/plugins/laf/lafs/flatlaf-1.0.jar
+%%DATADIR%%/plugins/laf/lafs/flatlaf-1.1.2.jar
 %%DATADIR%%/plugins/laf/lafs/ilf-gpl.jar
 %%DATADIR%%/plugins/laf/lafs/jgoodies-common-1.8.1.jar
 %%DATADIR%%/plugins/laf/lafs/jgoodies-looks-2.5.3.jar


### PR DESCRIPTION
It now requires Java 11 or higher.

Changelog:	https://sourceforge.net/p/squirrel-sql/git/ci/master/tree/sql12/core/doc/changes.txt

PR:		263167