### PR TITLE
dns/powerdns-recursor: Update to 4.6.2

### DIFF
--- a/dns/powerdns-recursor/Makefile
+++ b/dns/powerdns-recursor/Makefile
@@ -1,7 +1,7 @@
 # Created by: sten@blinkenlights.nl
 
 PORTNAME=	recursor
-DISTVERSION=	4.6.1
+DISTVERSION=	4.6.2
 CATEGORIES=	dns
 MASTER_SITES=	http://downloads.powerdns.com/releases/
 PKGNAMEPREFIX=	powerdns-

--- a/dns/powerdns-recursor/distinfo
+++ b/dns/powerdns-recursor/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1648224655
-SHA256 (pdns-recursor-4.6.1.tar.bz2) = 7b8500908b84a87ea8a021cbff3f6c1f9ff95f0199e7c972b15b93dfb1561ceb
-SIZE (pdns-recursor-4.6.1.tar.bz2) = 1541000
+TIMESTAMP = 1649243394
+SHA256 (pdns-recursor-4.6.2.tar.bz2) = da649850739fdd7baf2df645acc97752ccd390973b56b8e25171ea7b0d25ad20
+SIZE (pdns-recursor-4.6.2.tar.bz2) = 1552587


### PR DESCRIPTION
Changelog:	https://blog.powerdns.com/2022/04/04/powerdns-recursor-4-6-2-and-4-5-9-released/

PR:		263160