### PR TITLE
textproc/py-mkdocs-redirects: Update to 1.0.4

### DIFF
--- a/textproc/py-mkdocs-redirects/Makefile
+++ b/textproc/py-mkdocs-redirects/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	mkdocs-redirects
-DISTVERSION=	1.0.3
+DISTVERSIONPREFIX=	v
+DISTVERSION=	1.0.4
 CATEGORIES=	textproc python
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
 
@@ -16,8 +17,7 @@ TEST_DEPENDS=	${RUN_DEPENDS} \
 
 USES=		python:3.6+
 USE_GITHUB=	yes
-GH_ACCOUNT=	datarobot
-GH_TAGNAME=	07ef89796ec97be3c6ea2681441992d5d4bfa87b
+GH_ACCOUNT=	mkdocs
 USE_PYTHON=	autoplist concurrent distutils
 
 NO_ARCH=	yes

--- a/textproc/py-mkdocs-redirects/distinfo
+++ b/textproc/py-mkdocs-redirects/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1643884960
-SHA256 (datarobot-mkdocs-redirects-1.0.3-07ef89796ec97be3c6ea2681441992d5d4bfa87b_GH0.tar.gz) = 8e49d78981bb2cc3f2d00545907baea630d05e12407f40f4567af546a52fc87b
-SIZE (datarobot-mkdocs-redirects-1.0.3-07ef89796ec97be3c6ea2681441992d5d4bfa87b_GH0.tar.gz) = 6395
+TIMESTAMP = 1649434239
+SHA256 (mkdocs-mkdocs-redirects-v1.0.4_GH0.tar.gz) = 698f49fdee25697f640551ad16688d265735ff248788df8915c34dc1246daa43
+SIZE (mkdocs-mkdocs-redirects-v1.0.4_GH0.tar.gz) = 7028


### PR DESCRIPTION
Changelog:	https://github.com/mkdocs/mkdocs-redirects/releases/tag/v1.0.4

PR:		263157