### PR TITLE
textproc/py-mkdocs-redirects: Update to 1.2.0

### DIFF
--- a/textproc/py-mkdocs-redirects/Makefile
+++ b/textproc/py-mkdocs-redirects/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	mkdocs-redirects
 DISTVERSIONPREFIX=	v
-DISTVERSION=	1.1.0
+DISTVERSION=	1.2.0
 CATEGORIES=	textproc python
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
 
@@ -11,7 +11,7 @@ WWW=		https://github.com/mkdocs/mkdocs-redirects
 LICENSE=	MIT
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
-RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}mkdocs>=1.0.4:textproc/py-mkdocs@${PY_FLAVOR}
+RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}mkdocs>=1.1.1:textproc/py-mkdocs@${PY_FLAVOR}
 
 TEST_DEPENDS=	${RUN_DEPENDS} \
 		${PYTHON_PKGNAMEPREFIX}pytest>=0:devel/py-pytest@${PY_FLAVOR}

--- a/textproc/py-mkdocs-redirects/distinfo
+++ b/textproc/py-mkdocs-redirects/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1662373845
-SHA256 (mkdocs-mkdocs-redirects-v1.1.0_GH0.tar.gz) = c95deb33b6ccfe0950d515bf497f1b3d80df4bc0293007ae8df853d30db6fbca
-SIZE (mkdocs-mkdocs-redirects-v1.1.0_GH0.tar.gz) = 7000
+TIMESTAMP = 1663787105
+SHA256 (mkdocs-mkdocs-redirects-v1.2.0_GH0.tar.gz) = 9af93a4449150d3b1ff6a0c254351beb8cb6451de23ea4538fa85bb862e841d2
+SIZE (mkdocs-mkdocs-redirects-v1.2.0_GH0.tar.gz) = 7434


### PR DESCRIPTION
Changelog:	https://github.com/mkdocs/mkdocs-redirects/releases/tag/v1.2.0

PR:		266540