### PR TITLE
mail/dovecot-fts-flatcurve: Update to 0.3.3

### DIFF
--- a/mail/dovecot-fts-flatcurve/Makefile
+++ b/mail/dovecot-fts-flatcurve/Makefile
@@ -1,7 +1,6 @@
 PORTNAME=	fts-flatcurve
 DISTVERSIONPREFIX=	v
-DISTVERSION=	0.3.2
-PORTREVISION=	1
+DISTVERSION=	0.3.3
 CATEGORIES=	mail
 PKGNAMEPREFIX=	dovecot-
 
@@ -11,10 +10,10 @@ WWW=		https://github.com/slusarz/dovecot-fts-flatcurve
 
 LICENSE=	LGPL21
 
-BUILD_DEPENDS=	dovecot>=2.3.10:mail/dovecot
+BUILD_DEPENDS=	dovecot>=2.3.17:mail/dovecot
 LIB_DEPENDS=	libicuuc.so:devel/icu \
 		libxapian.so:databases/xapian-core
-RUN_DEPENDS=	dovecot>=2.3.10:mail/dovecot
+RUN_DEPENDS=	dovecot>=2.3.17:mail/dovecot
 
 USES=		autoreconf libtool pkgconfig
 USE_GITHUB=	yes

--- a/mail/dovecot-fts-flatcurve/distinfo
+++ b/mail/dovecot-fts-flatcurve/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1665207383
-SHA256 (slusarz-dovecot-fts-flatcurve-v0.3.2_GH0.tar.gz) = cea0fda2181e11bb54892e729360397e622d3f02934feae27107a70b61b74c44
-SIZE (slusarz-dovecot-fts-flatcurve-v0.3.2_GH0.tar.gz) = 49968
+TIMESTAMP = 1668750854
+SHA256 (slusarz-dovecot-fts-flatcurve-v0.3.3_GH0.tar.gz) = 9d7afb627a61af9e323c4046003acd8953e629794f4dbcd6f7b8e196624af59c
+SIZE (slusarz-dovecot-fts-flatcurve-v0.3.3_GH0.tar.gz) = 49874


### PR DESCRIPTION
Changelog:	https://github.com/slusarz/dovecot-fts-flatcurve/releases/tag/v0.3.3

PR:		267840