### PR TITLE
net-p2p/prowlarr: Update to 0.4.10.2111

### DIFF
--- a/net-p2p/prowlarr/Makefile
+++ b/net-p2p/prowlarr/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	prowlarr
-DISTVERSION=	0.4.9.2083
+DISTVERSION=	0.4.10.2111
 CATEGORIES=	net-p2p
 MASTER_SITES=	https://github.com/Prowlarr/Prowlarr/releases/download/v${PORTVERSION}/
 DISTNAME=	Prowlarr.develop.${PORTVERSION}.freebsd-core-x64

--- a/net-p2p/prowlarr/distinfo
+++ b/net-p2p/prowlarr/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1668361787
-SHA256 (Prowlarr.develop.0.4.9.2083.freebsd-core-x64.tar.gz) = 9701525d9436b9c2d3162cb78bba1ae777a67648cb3f64bf400423b959fa578a
-SIZE (Prowlarr.develop.0.4.9.2083.freebsd-core-x64.tar.gz) = 49020925
+TIMESTAMP = 1670666587
+SHA256 (Prowlarr.develop.0.4.10.2111.freebsd-core-x64.tar.gz) = e81939aa85b879be070e6903cdba4b08a092f79be8b0c7977294a8ec7179dd61
+SIZE (Prowlarr.develop.0.4.10.2111.freebsd-core-x64.tar.gz) = 48985148


### PR DESCRIPTION
Changelog:	https://github.com/Prowlarr/Prowlarr/releases/tag/v0.4.10.2111

PR:		268298