### PR TITLE
net/kamailio: Update to 5.6.2

### DIFF
--- a/net/kamailio/Makefile
+++ b/net/kamailio/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	kamailio
-PORTVERSION=	5.5.4
-PORTREVISION=	3
+PORTVERSION=	5.6.2
 CATEGORIES=	net
 MASTER_SITES=	http://www.kamailio.org/pub/kamailio/${PORTVERSION}/src/
 DISTNAME=	${PORTNAME}-${PORTVERSION}_src
@@ -39,9 +38,10 @@ WRKSRC=		${WRKDIR}/${PORTNAME}-${PORTVERSION}
 USERS=		${KAMAILIO_USER}
 GROUPS=		${KAMAILIO_GROUP}
 
-OPTIONS_DEFINE=			DATABASE DIALPLAN DOCS EVAPI JWT KAFKA LWSC \
-				MQTT OUTBOUND PERL PHONENUM PRESENCE RADIUS \
-				SCTP SECSIPID TLS WEBSOCKET
+OPTIONS_DEFINE=			DATABASE DIALPLAN DLGS DOCS EVAPI JWT KAFKA \
+				LOST LWSC MQTT OUTBOUND PERL PHONENUM POSOPS \
+				PRESENCE RADIUS SCTP SECSIPID SIPREPO SLACK \
+				SWORKER TLS WEBSOCKET
 OPTIONS_DEFAULT=		MYSQL PRESENCE RADIUS SQLITE TLS
 OPTIONS_GROUP=			DATABASE_DRIVERS KEMI_LANGS
 OPTIONS_GROUP_DATABASE_DRIVERS=	MYSQL PGSQL SQLITE UNIXODBC
@@ -51,25 +51,33 @@ OPTIONS_SUB=			YES
 DATABASE_DESC=		Database support
 DATABASE_DRIVERS_DESC=	Database drivers
 DIALPLAN_DESC=		String translations based on rules
+DLGS_DESC=		Lightweight, stateless dialog tracking and statistics
 EVAPI_DESC=		Network event broadcast API
 JWT_DESC=		JSON Web Token generation and validation
 KAFKA_DESC=		Produces and sends messages to a Kafka server
 KEMI_LANGS_DESC=	Kamailio Embedded Interface Interpreters
+LOST_DESC=		HELD (RFC6155) and LOST (RFC5222) location-based routing
 LUAJIT_DESC=		Execute embedded Lua scripts
 LWSC_DESC=		Websocket client connector using libwebsockets
 MQTT_DESC=		MQTT connector for bi-directional publish-subscribe communication
 OUTBOUND_DESC=		SIP Outbound support
 PHONENUM_DESC=		Phone number lookup and normalization using libphonenumber
+POSOPS_DESC=		Operations using the position in the SIP message buffer
 PRESENCE_DESC=		Presence support
 PYTHON3_DESC=		Execute embedded Python3 scripts
 SCTP_DESC=		SCTP support
 SECSIPID_DESC=		Secure SIP/Telephony Identity (STIR/SHAKEN) extensions
+SIPREPO_DESC=		In-memory SIP message storage
+SLACK_DESC=		Connector to Slack channels
+SWORKER_DESC=		Tasks management for specialized workers
 WEBSOCKET_DESC=		WebSocket transport layer
 
 DATABASE_VARS=	EXTRA_GROUPS+=db
 
 DIALPLAN_LIB_DEPENDS=	libpcre.so:devel/pcre
 DIALPLAN_VARS=		EXTRA_MODULES+=dialplan
+
+DLGS_VARS=	EXTRA_MODULES+=dlgs
 
 EVAPI_LIB_DEPENDS=	libev.so:devel/libev
 EVAPI_VARS=		EXTRA_MODULES+=evapi
@@ -79,6 +87,10 @@ JWT_VARS=		EXTRA_MODULES+=jwt
 
 KAFKA_LIB_DEPENDS=	librdkafka.so:net/librdkafka
 KAFKA_VARS=		EXTRA_MODULES+=kafka
+
+LOST_LIB_DEPENDS=	libcurl.so:ftp/curl \
+			libxml2.so:textproc/libxml2
+LOST_VARS=		EXTRA_MODULES+=lost
 
 LUAJIT_USES=		luajit
 LUAJIT_MAKE_ARGS=	LUAJIT=yes
@@ -110,6 +122,8 @@ PGSQL_VARS=	EXTRA_GROUPS+=postgres
 PHONENUM_LIB_DEPENDS=	libphonenumber.so:devel/libphonenumber
 PHONENUM_VARS=		EXTRA_MODULES+=phonenum
 
+POSOPS_VARS=	EXTRA_MODULES+=posops
+
 PRESENCE_LIB_DEPENDS=	libcurl.so:ftp/curl \
 			libxml2.so:textproc/libxml2
 PRESENCE_VARS=		EXTRA_GROUPS+=presence
@@ -125,9 +139,16 @@ SCTP_VARS=	EXTRA_MODULES+=sctp
 
 SECSIPID_VARS=	EXTRA_MODULES+=secsipid
 
+SIPREPO_VARS=	EXTRA_MODULES+=siprepo
+
+SLACK_LIB_DEPENDS=	libcurl.so:ftp/curl
+SLACK_VARS=		EXTRA_MODULES+=slack
+
 SQLITE_IMPLIES=	DATABASE
 SQLITE_USES=	sqlite
 SQLITE_VARS=	EXTRA_MODULES+=db_sqlite
+
+SWORKER_VARS=	EXTRA_MODULES+=sworker
 
 TLS_USES=	ssl
 TLS_VARS=	EXTRA_MODULES+=tls

--- a/net/kamailio/distinfo
+++ b/net/kamailio/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1645470840
-SHA256 (kamailio-5.5.4_src.tar.gz) = 991d081abc6ee2efdbdb85ee7398f8812f2bdb9ab30ccf9ae0ace6562943860a
-SIZE (kamailio-5.5.4_src.tar.gz) = 12794910
+TIMESTAMP = 1665134014
+SHA256 (kamailio-5.6.2_src.tar.gz) = ea3cd5d688c34208b92072c3844c8276b693e0ca2c688168ea0357978c76b32d
+SIZE (kamailio-5.6.2_src.tar.gz) = 12921131

--- a/net/kamailio/files/patch-src_core_cfg.y
+++ b/net/kamailio/files/patch-src_core_cfg.y
@@ -1,0 +1,43 @@
+--- src/core/cfg.y.orig	(revision 2cebd46f8f2dc3f87c9cfd2054976e347aa75ace)
++++ src/core/cfg.y
+@@ -2045,14 +2045,38 @@
+ module_stm:
+ 	LOADMODULE STRING {
+ 		LM_DBG("loading module %s\n", $2);
+-			if (load_module($2)!=0) {
++			if (ksr_load_module($2, NULL)!=0) {
++				yyerror("failed to load module");
++			}
++	}
++	| LOADMODULE LPAREN STRING RPAREN {
++		LM_DBG("loading module %s\n", $3);
++			if (ksr_load_module($3, NULL)!=0) {
++				yyerror("failed to load module");
++			}
++	}
++	| LOADMODULE LPAREN STRING COMMA STRING RPAREN {
++		LM_DBG("loading module %s opts %s\n", $3, $5);
++			if (ksr_load_module($3, $5)!=0) {
+ 				yyerror("failed to load module");
+ 			}
+ 	}
+ 	| LOADMODULE error	{ yyerror("string expected"); }
+ 	| LOADMODULEX STRING {
+ 		LM_DBG("loading module %s\n", $2);
+-			if (load_modulex($2)!=0) {
++			if (ksr_load_modulex($2, NULL)!=0) {
++				yyerror("failed to load module");
++			}
++	}
++	| LOADMODULEX LPAREN STRING RPAREN {
++		LM_DBG("loading module %s\n", $3);
++			if (ksr_load_modulex($3, NULL)!=0) {
++				yyerror("failed to load module");
++			}
++	}
++	| LOADMODULEX LPAREN STRING COMMA STRING RPAREN {
++		LM_DBG("loading module %s opts %s\n", $3, $5);
++			if (ksr_load_modulex($3, $5)!=0) {
+ 				yyerror("failed to load module");
+ 			}
+ 	}

--- a/net/kamailio/files/patch-src_core_sr__module.c
+++ b/net/kamailio/files/patch-src_core_sr__module.c
@@ -1,0 +1,79 @@
+--- src/core/sr_module.c.orig	(revision 43f764cae870b15a96b8ca88f1eb195d4ceb8455)
++++ src/core/sr_module.c
+@@ -525,6 +525,7 @@
+ 	return -1;
+ }
+ 
++
+ /**
+  * \brief load a sr module
+  *
+@@ -537,9 +538,10 @@
+  * absolute path (not starting with '/') then will try:
+  * \<MODS_DIR\>/mod_path
+  * @param mod_path path or module name
++ * @param opts options string
+  * @return 0 on success , <0 on error
+  */
+-int load_module(char* mod_path)
++int ksr_load_module(char* mod_path, char *opts)
+ {
+ 	void* handle;
+ 	char* error;
+@@ -553,11 +555,16 @@
+ 	str expref;
+ 	char exbuf[64];
+ 	char* mdir;
++	char *p;
+ 
+ #ifndef RTLD_NOW
+ /* for openbsd */
+ #define RTLD_NOW DL_LAZY
+ #endif
++#ifndef RTLD_GLOBAL
++/* Unsupported! */
++#define RTLD_GLOBAL 0
++#endif
+ 
+ 	if(ksr_locate_module(mod_path, &path)<0) {
+ 		return -1;
+@@ -567,6 +574,17 @@
+ 
+ 	retries=2;
+ 	dlflags=RTLD_NOW;
++
++	if(opts!=NULL) {
++		for(p=opts; *p!='\0'; p++) {
++			if(*p=='G' || *p=='g') {
++				dlflags |= RTLD_GLOBAL;
++			} else {
++				LM_INFO("unknown option: %c\n", *p);
++			}
++		}
++	}
++
+ reload:
+ 	handle=dlopen(path, dlflags); /* resolve all symbols now */
+ 	if (handle==0){
+@@ -653,10 +671,11 @@
+ 	return -1;
+ }
+ 
++
+ /**
+  *
+  */
+-int load_modulex(char* mod_path)
++int ksr_load_modulex(char* mod_path, char *opts)
+ {
+ 	str seval;
+ 	str sfmt;
+@@ -679,7 +698,7 @@
+ 		}
+ 	}
+ 
+-	return load_module(emod);
++	return ksr_load_module(emod, opts);
+ }
+ 
+ /**

--- a/net/kamailio/files/patch-src_core_sr__module.h
+++ b/net/kamailio/files/patch-src_core_sr__module.h
@@ -1,0 +1,13 @@
+--- src/core/sr_module.h.orig	(revision 43f764cae870b15a96b8ca88f1eb195d4ceb8455)
++++ src/core/sr_module.h
+@@ -336,8 +336,8 @@
+ extern int mod_response_cbk_no; /**< size of reponse callbacks array */
+ 
+ int register_builtin_modules(void);
+-int load_module(char* path);
+-int load_modulex(char* path);
++int ksr_load_module(char* path, char* opts);
++int ksr_load_modulex(char* path, char* opts);
+ ksr_cmd_export_t* find_export_record(char* name, int param_no, int flags);
+ cmd_function find_export(char* name, int param_no, int flags);
+ cmd_function find_mod_export(char* mod, char* name, int param_no, int flags);

--- a/net/kamailio/files/patch-src_main.c
+++ b/net/kamailio/files/patch-src_main.c
@@ -1,0 +1,11 @@
+--- src/main.c.orig	(revision 43f764cae870b15a96b8ca88f1eb195d4ceb8455)
++++ src/main.c
+@@ -2446,7 +2446,7 @@
+ 						fprintf(stderr, "bad load module parameter\n");
+ 						goto error;
+ 					}
+-					if (load_module(optarg)!=0) {
++					if (ksr_load_module(optarg, NULL)!=0) {
+ 						LM_ERR("failed to load the module: %s\n", optarg);
+ 						goto error;
+ 					}

--- a/net/kamailio/pkg-message
+++ b/net/kamailio/pkg-message
@@ -1,0 +1,14 @@
+[
+{
+  type: install
+  message: <<EOM
+There's a regression after enabling ASLR (ex., enabled on stable/13 by default).
+Kamailio causes SIGSEGV while loading KEMI Interpreters probably.
+It's need to disable ASLR:
+# sysctl kern.elf64.aslr.enable=0
+# sysctl kern.elf64.aslr.pie_enable=0
+or load KEMI Interpreters with RTLD_GLOBAL flag, ex.:
+loadmodule("app_lua.so", "g")
+EOM
+}
+]

--- a/net/kamailio/pkg-plist
+++ b/net/kamailio/pkg-plist
@@ -144,12 +144,16 @@
 %%DATABASE%%lib/kamailio/modules/usrloc.so
 %%DIALPLAN%%%%PORTDOCS%%%%DOCSDIR%%/modules/README.dialplan
 %%DIALPLAN%%lib/kamailio/modules/dialplan.so
+%%DLGS%%%%PORTDOCS%%%%DOCSDIR%%/modules/README.dlgs
+%%DLGS%%lib/kamailio/modules/dlgs.so
 %%EVAPI%%%%PORTDOCS%%%%DOCSDIR%%/modules/README.evapi
 %%EVAPI%%lib/kamailio/modules/evapi.so
 %%JWT%%%%PORTDOCS%%%%DOCSDIR%%/modules/README.jwt
 %%JWT%%lib/kamailio/modules/jwt.so
 %%KAFKA%%%%PORTDOCS%%%%DOCSDIR%%/modules/README.kafka
 %%KAFKA%%lib/kamailio/modules/kafka.so
+%%LOST%%%%PORTDOCS%%%%DOCSDIR%%/modules/README.lost
+%%LOST%%lib/kamailio/modules/lost.so
 %%LUAJIT%%%%PORTDOCS%%%%DOCSDIR%%/modules/README.app_lua
 %%LUAJIT%%lib/kamailio/modules/app_lua.so
 %%LWSC%%%%PORTDOCS%%%%DOCSDIR%%/modules/README.lwsc
@@ -318,10 +322,10 @@
 %%PORTDOCS%%%%DOCSDIR%%/modules/README.kex
 %%PORTDOCS%%%%DOCSDIR%%/modules/README.log_custom
 %%PORTDOCS%%%%DOCSDIR%%/modules/README.lrkproxy
-%%PORTDOCS%%%%DOCSDIR%%/modules/README.malloc_test
 %%PORTDOCS%%%%DOCSDIR%%/modules/README.mangler
 %%PORTDOCS%%%%DOCSDIR%%/modules/README.maxfwd
 %%PORTDOCS%%%%DOCSDIR%%/modules/README.mediaproxy
+%%PORTDOCS%%%%DOCSDIR%%/modules/README.misctest
 %%PORTDOCS%%%%DOCSDIR%%/modules/README.mqueue
 %%PORTDOCS%%%%DOCSDIR%%/modules/README.msrp
 %%PORTDOCS%%%%DOCSDIR%%/modules/README.nat_traversal
@@ -374,6 +378,8 @@
 %%PORTDOCS%%%%DOCSDIR%%/modules/README.xhttp_rpc
 %%PORTDOCS%%%%DOCSDIR%%/modules/README.xlog
 %%PORTDOCS%%%%DOCSDIR%%/modules/README.xprint
+%%POSOPS%%%%PORTDOCS%%%%DOCSDIR%%/modules/README.posops
+%%POSOPS%%lib/kamailio/modules/posops.so
 %%PRESENCE%%%%PORTDOCS%%%%DOCSDIR%%/modules/README.presence
 %%PRESENCE%%%%PORTDOCS%%%%DOCSDIR%%/modules/README.presence_conference
 %%PRESENCE%%%%PORTDOCS%%%%DOCSDIR%%/modules/README.presence_dialoginfo
@@ -423,6 +429,10 @@
 %%SCTP%%lib/kamailio/modules/sctp.so
 %%SECSIPID%%%%PORTDOCS%%%%DOCSDIR%%/modules/README.secsipid
 %%SECSIPID%%lib/kamailio/modules/secsipid.so
+%%SIPREPO%%%%PORTDOCS%%%%DOCSDIR%%/modules/README.siprepo
+%%SIPREPO%%lib/kamailio/modules/siprepo.so
+%%SLACK%%%%PORTDOCS%%%%DOCSDIR%%/modules/README.slack
+%%SLACK%%lib/kamailio/modules/slack.so
 %%SQLITE%%%%DATADIR%%/db_sqlite/acc-create.sql
 %%SQLITE%%%%DATADIR%%/db_sqlite/alias_db-create.sql
 %%SQLITE%%%%DATADIR%%/db_sqlite/auth_db-create.sql
@@ -471,6 +481,8 @@
 %%SQLITE%%lib/kamailio/kamctl/kamctl.sqlite
 %%SQLITE%%lib/kamailio/kamctl/kamdbctl.sqlite
 %%SQLITE%%lib/kamailio/modules/db_sqlite.so
+%%SWORKER%%%%PORTDOCS%%%%DOCSDIR%%/modules/README.sworker
+%%SWORKER%%lib/kamailio/modules/sworker.so
 %%TLS%%%%PORTDOCS%%%%DOCSDIR%%/modules/README.tls
 %%TLS%%@sample %%ETCDIR%%/tls.cfg.sample
 %%TLS%%lib/kamailio/modules/tls.so
@@ -527,10 +539,10 @@ lib/kamailio/modules/kemix.so
 lib/kamailio/modules/kex.so
 lib/kamailio/modules/log_custom.so
 lib/kamailio/modules/lrkproxy.so
-lib/kamailio/modules/malloc_test.so
 lib/kamailio/modules/mangler.so
 lib/kamailio/modules/maxfwd.so
 lib/kamailio/modules/mediaproxy.so
+lib/kamailio/modules/misctest.so
 lib/kamailio/modules/mqueue.so
 lib/kamailio/modules/msrp.so
 lib/kamailio/modules/nat_traversal.so


### PR DESCRIPTION
- Added dlgs, lost, posops, siprepo, slack and sworker modules.
- Also backported (from master branch) ASLR support for KEMI modules (see pkg-message).

Changelog:	https://www.kamailio.org/pub/kamailio/5.6.2/ChangeLog

PR:		268670